### PR TITLE
config.c: add missing #include for musl libc

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -30,6 +30,7 @@
 #include <sys/types.h>
 #include <dirent.h>
 #include <ctype.h>
+#include <limits.h>
 #include "config.h"
 #include "keys.h"
 


### PR DESCRIPTION
Commit message says it all. Wasn't able to compile on musl without this line. Previously gcc would complain about PATH_MAX being undeclared.