### PR TITLE
Moved -ludev in compile script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,11 @@
 
 VERSION=0.0.1
 GIT_HASH=$(shell git describe --no-match --always --abbrev=40 --dirty)
-CFLAGS=-DVERSION=\"$(VERSION)\" -DGIT_COMMIT_HASH=\"$(GIT_HASH)\" -ludev 
+CFLAGS=-DVERSION=\"$(VERSION)\" -DGIT_COMMIT_HASH=\"$(GIT_HASH)\"
 
 all:
 	-mkdir bin
-	$(CC) $(CFLAGS) -O3 src/*.c -o bin/keyd
+	$(CC) $(CFLAGS) -O3 src/*.c -o bin/keyd -ludev
 debug:
 	-mkdir bin
 	$(CC) $(CFLAGS) -Wall -Wextra -DDEBUG -g  src/*.c -o bin/keyd


### PR DESCRIPTION
On my machine with Linux ` 5.8.0-63-generic #71~20.04.1-Ubuntu SMP` and libudev: `libudev-dev/focal-updates,focal-security,now 245.4-4ubuntu3.11 amd64` the makefile did not compile the binary and returned this linker messages:
```
/usr/bin/ld: /tmp/ccRNvVGZ.o: in function `exit_signal_handler':
main.c:(.text+0x20c): undefined reference to `udev_unref'
/usr/bin/ld: main.c:(.text+0x218): undefined reference to `udev_monitor_unref'
/usr/bin/ld: /tmp/ccRNvVGZ.o: in function `is_keyboard.part.0':
main.c:(.text+0x47b): undefined reference to `udev_device_get_properties_list_entry'
/usr/bin/ld: main.c:(.text+0x4a4): undefined reference to `udev_list_entry_get_next'
/usr/bin/ld: main.c:(.text+0x4b4): undefined reference to `udev_list_entry_get_name'
/usr/bin/ld: main.c:(.text+0x4d2): undefined reference to `udev_list_entry_get_value'
/usr/bin/ld: main.c:(.text+0x4e5): undefined reference to `udev_list_entry_get_name'
/usr/bin/ld: main.c:(.text+0x503): undefined reference to `udev_list_entry_get_value'
/usr/bin/ld: main.c:(.text+0x51d): undefined reference to `udev_list_entry_get_next'
/usr/bin/ld: /tmp/ccRNvVGZ.o: in function `get_keyboard_nodes':
main.c:(.text+0x577): undefined reference to `udev_new'
/usr/bin/ld: main.c:(.text+0x58b): undefined reference to `udev_enumerate_new'
/usr/bin/ld: main.c:(.text+0x5ab): undefined reference to `udev_enumerate_add_match_subsystem'
/usr/bin/ld: main.c:(.text+0x5ba): undefined reference to `udev_enumerate_add_match_subsystem'
/usr/bin/ld: main.c:(.text+0x5c2): undefined reference to `udev_enumerate_scan_devices'
/usr/bin/ld: main.c:(.text+0x5ca): undefined reference to `udev_enumerate_get_list_entry'
/usr/bin/ld: main.c:(.text+0x5f4): undefined reference to `udev_list_entry_get_name'
/usr/bin/ld: main.c:(.text+0x5ff): undefined reference to `udev_device_new_from_syspath'
/usr/bin/ld: main.c:(.text+0x60a): undefined reference to `udev_device_get_devnode'
/usr/bin/ld: main.c:(.text+0x615): undefined reference to `udev_device_get_devnode'
/usr/bin/ld: main.c:(.text+0x68a): undefined reference to `udev_device_unref'
/usr/bin/ld: main.c:(.text+0x692): undefined reference to `udev_list_entry_get_next'
/usr/bin/ld: main.c:(.text+0x6a8): undefined reference to `udev_enumerate_unref'
/usr/bin/ld: /tmp/ccRNvVGZ.o: in function `main_loop':
main.c:(.text+0xc02): undefined reference to `udev_new'
/usr/bin/ld: main.c:(.text+0xc18): undefined reference to `udev_monitor_new_from_netlink'
/usr/bin/ld: main.c:(.text+0xc45): undefined reference to `udev_monitor_filter_add_match_subsystem_devtype'
/usr/bin/ld: main.c:(.text+0xc51): undefined reference to `udev_monitor_enable_receiving'
/usr/bin/ld: main.c:(.text+0xc5d): undefined reference to `udev_monitor_get_fd'
/usr/bin/ld: main.c:(.text+0x11a8): undefined reference to `udev_monitor_receive_device'
/usr/bin/ld: main.c:(.text+0x11b3): undefined reference to `udev_device_get_devnode'
/usr/bin/ld: main.c:(.text+0x11c3): undefined reference to `udev_device_get_devnode'
/usr/bin/ld: main.c:(.text+0x11f0): undefined reference to `udev_device_get_action'
/usr/bin/ld: main.c:(.text+0x1234): undefined reference to `udev_device_unref'
/usr/bin/ld: /tmp/ccRNvVGZ.o: in function `get_keyboard_nodes':
main.c:(.text+0x6be): undefined reference to `udev_unref'
collect2: error: ld returned 1 exit status
make: *** [Makefile:9: all] Error 1
```
By moving -ludev at the end of the compilation directive now the file compiles with no problem.