### PR TITLE
Add support for DESTDIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,6 @@ clean:
 	-rm -rf bin
 install:
 	-mkdir /etc/keyd
-	install -m755 keyd.service /usr/lib/systemd/system
-	install -m755 bin/keyd /usr/bin
-	install -m644 keyd.1.gz /usr/share/man/man1/
+	install -Dm755 keyd.service $(DESTDIR)/lib/systemd/system
+	install -Dm755 bin/keyd $(DESTDIR)/bin/keyd
+	install -Dm644 keyd.1.gz $(DESTDIR)/share/man/man1/keyd.1.gz

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Some of the more interesting ones include:
 
     git clone https://github.com/rvaiya/keyd
     cd keyd
-    make && sudo make install
+    make && sudo make DESTDIR=/usr install
     sudo systemctl enable keyd && sudo systemctl start keyd
 
 # Quickstart


### PR DESCRIPTION
On some systems (NixOS for example), not everything is in /usr.
This adds support for these kinds of systems by supporting DESTDIR, and updates the README accordingly.
