### PR TITLE
main: drop unused <linux/limits.h>

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -24,7 +24,6 @@
 #include <sys/time.h>
 #include <signal.h>
 #include <sys/types.h>
-#include <linux/limits.h>
 #include <sys/file.h>
 #include <dirent.h>
 #include <assert.h>


### PR DESCRIPTION
FreeBSD supports [uinput](https://github.com/freebsd/freebsd-src/blob/releng/13.0/sys/dev/evdev/uinput.c), so keyd may work. See also [untested package](https://github.com/freebsd/freebsd-ports/commit/21736338c325).
```c
$ pkg install evdev-proto libudev-devd gmake
$ export CPATH=/usr/local/include LIBRARY_PATH=/usr/local/lib
$ gmake
mkdir bin
cc -DVERSION=\"0.0.1\" -DGIT_COMMIT_HASH=\"ac0d827d416f82565f60475aa58917dedf6bc574\" -O3 src/*.c -o bin/keyd -ludev
src/main.c:27:10: fatal error: 'linux/limits.h' file not found
#include <linux/limits.h>
         ^~~~~~~~~~~~~~~~
1 error generated.
gmake: *** [Makefile:12: all] Error 1
```
