### PR TITLE
Add the ability to override the config directory

### DIFF
--- a/man.md
+++ b/man.md
@@ -26,7 +26,8 @@ be stored in /var/log/keyd.log.
 
 # CONFIGURATION
 
-All configuration files are stored in /etc/keyd. The name of each file should
+All configuration files are stored in /etc/keyd. Optionally, one can override
+this by setting `KEYD_CONFIG_DIR`. The name of each file should
 correspond to the device name to which it is to be applied followed
 by .cfg (e.g "/etc/keyd/Magic Keyboard.cfg"). Configuration files are loaded
 upon initialization and can be reified by reloading keyd

--- a/src/config.c
+++ b/src/config.c
@@ -560,10 +560,26 @@ void config_free()
 	};
 }
 
+char* get_config_dir()
+{
+	char *keyd_config;
+
+	keyd_config = getenv("KEYD_CONFIG_DIR");
+	if (keyd_config) {
+		DIR *config_dir = opendir(keyd_config);
+		if (config_dir) {
+			return config_dir;
+		}
+	}
+
+	return CONFIG_DIR;
+}
+
 void config_generate()
 {
 	struct dirent *ent;
-	DIR *dh = opendir(CONFIG_DIR);
+	char *config_dir = get_config_dir();
+	DIR *dh = opendir(config_dir);
 
 	if(!dh) {
 		perror("opendir");
@@ -599,4 +615,5 @@ void config_generate()
 	}
 
 	closedir(dh);
+	free(config_dir);
 }


### PR DESCRIPTION
This allows the user to override the location of /etc/keyd by setting
`KEYD_CONFIG_DIR`. This allows, for example, allows users to seperate
configs.
