### PR TITLE
Change include <linux/*> to <*>. Make it easier to compile on freebsd.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,7 @@
 *.swo
 *.out
 tags
+compile_commands.json
 bin/
+.cache/
 *.gch

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,10 @@ CONFIG_DIR="/etc/keyd"
 VERSION=1.1.2
 GIT_HASH=$(shell git describe --no-match --always --abbrev=40 --dirty)
 
-CFLAGS=-DVERSION=\"$(VERSION)\" \
+# for input.h input-event-codes.h uinput.h
+CPPFLAGS=-idirafter /usr/include/linux
+
+CONFIG=-DVERSION=\"$(VERSION)\" \
 	-DGIT_COMMIT_HASH=\"$(GIT_HASH)\" \
 	-DCONFIG_DIR=\"$(CONFIG_DIR)\" \
 	-DLOG_FILE=\"$(LOG_FILE)\" \
@@ -18,7 +21,7 @@ CFLAGS=-DVERSION=\"$(VERSION)\" \
 
 all:
 	mkdir -p bin
-	$(CC) $(CFLAGS) -O3 src/*.c -o bin/keyd -ludev
+	$(CC) -O3 $(CONFIG) $(CPPFLAGS) $(LDFLAGS) src/*.c -o bin/keyd -ludev
 man:
 	pandoc -s -t man man.md | gzip > keyd.1.gz
 clean:

--- a/src/config.h
+++ b/src/config.h
@@ -23,7 +23,7 @@
 #ifndef __H_CONFIG_
 #define __H_CONFIG_
 
-#include <linux/input-event-codes.h>
+#include <input-event-codes.h>
 #include <stdint.h>
 #include <stddef.h>
 #include "keys.h"

--- a/src/keys.h
+++ b/src/keys.h
@@ -24,7 +24,7 @@
 #define _KEYS_H_
 #define _KEYS_H_
 
-#include <linux/input-event-codes.h>
+#include <input-event-codes.h>
 #include <stdint.h>
 
 #define MOD_ALT_GR 0x10

--- a/src/main.c
+++ b/src/main.c
@@ -29,11 +29,11 @@
 #include <assert.h>
 #include <string.h>
 #include <unistd.h>
-#include <linux/input.h>
+#include <input.h>
 #include <libudev.h>
 #include <stdint.h>
 #include <stdarg.h>
-#include <linux/uinput.h>
+#include <uinput.h>
 #include <time.h>
 #include <stdlib.h>
 #include <fcntl.h>


### PR DESCRIPTION
Change include <linux/*> to <*>. Make it easier to compile on freebsd.

With this change you can compile from freebsd without patches while using the same Makefile:

```
# pkg install libudev-devd
$ make CPPFLAGS='-I/usr/local/include -I/usr/include/dev/evdev' LDFLAGS='-L/usr/local/lib'
```
