### PR TITLE
Enables NixOS compatability

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,13 @@
+with import <nixpkgs> {};
+stdenv.mkDerivation rec {
+    pname = "keyd";
+    version = "1.1.2";
+    src = null;
+    buildInputs = [ pkgconfig libudev ];
+    meta = {
+      license = lib.licenses.mit;
+      homepage = "https://github.com/rvaiya/keyd";
+      description = "Remap keys using kernel-level input primitives (evdev, uinput).";
+    };
+    platforms = lib.platforms.all;
+}

--- a/src/config.c
+++ b/src/config.c
@@ -618,7 +618,11 @@ static void build_layer_table()
 	FILE *fh = fopen(path, "r");
 
 	if(!fh) {
-		perror("fopen");
+		int err_str_size = sizeof(path) + 6;
+		char *err_str = malloc(err_str_size);
+		snprintf(err_str, err_str_size, "fopen %s", path);
+		perror(err_str);
+		free(err_str);
 		exit(-1);
 	}
 
@@ -834,10 +838,20 @@ void config_free()
 	};
 }
 
-void config_generate()
+void config_generate(char* config_path_override)
 {
 	struct dirent *ent;
-	DIR *dh = opendir(CONFIG_DIR);
+	DIR *dh;
+
+	char *config_dir_path;
+
+	if(config_path_override != NULL) {
+		config_dir_path = config_path_override;
+	} else {
+		config_dir_path = CONFIG_DIR;
+	}
+
+	dh = opendir(config_dir_path);
 
 	if(!dh) {
 		perror("opendir");
@@ -852,7 +866,7 @@ void config_generate()
 			continue;
 
 
-		sprintf(path, "%s/%s", CONFIG_DIR, ent->d_name);
+		sprintf(path, "%s/%s", config_dir_path, ent->d_name);
 
 		cfg = calloc(1, sizeof(struct keyboard_config));
 

--- a/src/main.c
+++ b/src/main.c
@@ -988,7 +988,14 @@ int main(int argc, char *argv[])
 		daemonize();
 
 	warn("Starting keyd v%s (%s).", VERSION, GIT_COMMIT_HASH);
-	config_generate();
+
+	if(argc > 1 && !strcmp(argv[1], "-c")) {
+		config_generate(argv[2]);
+	}
+	else {
+		config_generate(NULL);
+	}
+
 	vkbd = create_virtual_keyboard();
 	vptr = create_virtual_pointer();
 


### PR DESCRIPTION
The keyd Makefile assumes the Filesystem Hierarchy Standard, which NixOS does not conform to. I wrote this patch to allow the -c flag to specify an alternative to the /etc/keyd config directory.

It looks like this option precludes the use of other flags (e.g. -d) at the same time.

I don't write C code very often -- sorry there is likely a much better way to do this.

Cheers for the great work on keyd. I appreciate it.
