### PR TITLE
Config dir, log file and lock file command line options

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -877,10 +877,10 @@ void config_free()
 	};
 }
 
-void config_generate()
+void config_generate(const char *config_dir)
 {
 	struct dirent *ent;
-	DIR *dh = opendir(CONFIG_DIR);
+	DIR *dh = opendir(config_dir);
 
 	if (!dh) {
 		perror("opendir");
@@ -895,7 +895,7 @@ void config_generate()
 			continue;
 
 
-		sprintf(path, "%s/%s", CONFIG_DIR, ent->d_name);
+		sprintf(path, "%s/%s", config_dir, ent->d_name);
 
 		cfg = calloc(1, sizeof(struct keyboard_config));
 


### PR DESCRIPTION
Adds command line options for config dir, log file and lock file.

Keeps full backwards compatibility,
the default is to use the hardcoded CONFIG_DIR, LOG_FILE and LOCK_FILE.

Additionally took the opportunity to rewrite the command line option parsing using getopt.