### PR TITLE
Prepend 'reset' to list of expressions for per-app bindings

### DIFF
--- a/scripts/keyd-application-mapper
+++ b/scripts/keyd-application-mapper
@@ -271,9 +271,13 @@ def on_window_change(cls):
         print(cls)
         return
 
+    expressions = ['reset']
+
     if cls in bindings:
-        # Apply the bindings.
-        subprocess.run(['keyd', '-e', *bindings[cls]])
+        expressions.extend(bindings[cls])
+
+    # Apply the bindings.
+    subprocess.run(['keyd', '-e', *expressions])
 
 
 mon = get_monitor(on_window_change)


### PR DESCRIPTION
Prevents per-app key bindings from carrying over to unintended apps