### PR TITLE
keyd.service: Restart=on-failure; WantedBy=multi-user.target

### DIFF
--- a/keyd.service
+++ b/keyd.service
@@ -6,6 +6,7 @@ After=local-fs.target
 [Service]
 Type=simple
 ExecStart=/usr/bin/keyd
+Restart=on-failure
 
 [Install]
-WantedBy=sysinit.target
+WantedBy=multi-user.target


### PR DESCRIPTION
This systemd service works better for me.

When `Restart=on-failure` and `WantedBy=sysinit.target` is used keyd fails and trips systemd's default 5 restart limit. There is no cause in journalctl, only a failure exit status.

`WantedBy=multi-user.target` seems better to me.