### PR TITLE
Unbreak build on FreeBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,12 +17,13 @@ CFLAGS+=-DVERSION=\"$(VERSION)\" \
 	-DSOCKET=\"$(SOCKET)\" \
 	-DLOCK_FILE=\"$(LOCK_FILE)\" \
 	-I/usr/local/include \
-	-L/usr/local/lib\
+	-L/usr/local/lib
+LDFLAGS+=$(shell if [ `uname -s` != Linux ]; then echo -linotify; fi)
 
 all: vkbd-uinput
 vkbd-%:
 	mkdir -p bin
-	$(CC) $(CFLAGS) -O3 src/*.c src/vkbd/$(@:vkbd-%=%).c -o bin/keyd -lpthread
+	$(CC) $(CFLAGS) -O3 src/*.c src/vkbd/$(@:vkbd-%=%).c -o bin/keyd -lpthread $(LDFLAGS)
 debug:
 	CFLAGS+="-pedantic -Wall -Wextra -g" $(MAKE)
 man:

--- a/src/config.c
+++ b/src/config.c
@@ -27,6 +27,7 @@
 #include <stdlib.h>
 #include <assert.h>
 #include <fcntl.h>
+#include <limits.h>
 #include <unistd.h>
 #include "ini.h"
 #include "keys.h"


### PR DESCRIPTION
udev on systemd-less Linux could be used via [libudev-zero](https://github.com/illiliti/libudev-zero) but since the ship has sailed let's use [libinotify-kqueue](https://github.com/libinotify-kqueue/libinotify-kqueue) on BSDs.