### PR TITLE
keyd.service: Add reload action

### DIFF
--- a/keyd.service
+++ b/keyd.service
@@ -6,6 +6,7 @@ After=local-fs.target
 [Service]
 Type=simple
 ExecStart=/usr/bin/keyd
+ExecReload=/bin/kill -USR1 $MAINPID
 
 [Install]
 WantedBy=sysinit.target


### PR DESCRIPTION
The service file now tells `systemd` how to reload `keyd`, allowing the user to reload configuration by running `sudo systemctl reload keyd`.