### PR TITLE
Fix bug introduced in a1edfab

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ man:
 	done
 install:
 	@if [ -e $(DESTDIR)$(PREFIX)/lib/systemd/ ]; then \
-		install -Dm644 keyd.service $(DESTDIR)$(PREFIX)/lib/systemd/system; \
+		install -Dm644 keyd.service $(DESTDIR)$(PREFIX)/lib/systemd/system/keyd.service; \
 	else \
 		echo "NOTE: systemd not found, you will need to manually add keyd to your system's init process."; \
 	fi


### PR DESCRIPTION
There was a bug introduced in a1edfab5d124aa70493dd988973f17bf4a9a4c30

https://github.com/rvaiya/keyd/blob/a1edfab5d124aa70493dd988973f17bf4a9a4c30/Makefile#L34

If `$(DESTDIR)$(PREFIX)/lib/systemd` exists, but there is no `systemd/system` directory, install will treat the command as "Install keyd.service into the **file** .../systemd/system" rather than "create a directory called system if it doesn't exist and install keyd.service within it". Adding the desired file name to the destination path fixes this.