### PR TITLE
change/fix formatting in usb-gadget.md, fix broken man page link

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,6 +1,6 @@
 streamline test logic
 organize tests
-cleanup manpage
+cleanup man page
 [idea] tmux like layer timeouts
 toggleable composite layers?
 improved mouse support (integrate moused?)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -176,4 +176,4 @@ oneshot_layer(layer)        = oneshot(layer)
 [dvorak:default]            = [dvorak:main]
 ```
 
-See the [manpage](man.md) for details.
+See the man page (`man keyd`) for details.

--- a/src/vkbd/usb-gadget.md
+++ b/src/vkbd/usb-gadget.md
@@ -8,7 +8,6 @@ Under this kind of setup, the Linux USB HID gadget driver can be used to emulate
 a HID device and `keyd` can be configured to translate evdev input events to
 HID reports.
 
-
 # Installation
 
     git clone https://github.com/rvaiya/keyd
@@ -17,8 +16,6 @@ HID reports.
     sudo systemctl enable usb-gadget && sudo systemctl start usb-gadget
     sudo systemctl enable keyd && sudo systemctl start keyd
 
-The device should show up as` 1d6b:0104 Linux Foundation Multifunction Composite Gadget`
+The device should show up as `1d6b:0104 Linux Foundation Multifunction Composite Gadget`
 on the host machine. This can be observed on a Linux host by checking the output of
 `lsof` or the existence of `/dev/input/by-id/Tux_USB_Gadget_Keyboard`.
-
-


### PR DESCRIPTION
Fixed code that had an extra space and removed extra newlines that don't affect the doc's rendered appearance.

Also fixed a broken man page link in CHANGELOG.md and changed instances of 'manpage' to 'man page'