### PR TITLE
application-mapper: gracefully handle Sway edge case

### DIFF
--- a/scripts/keyd-application-mapper
+++ b/scripts/keyd-application-mapper
@@ -112,8 +112,11 @@ class SwayMonitor():
                     cls = props['class']
                     title = props['title']
             except:
-                title = ''
-                cls = data['container']['app_id']
+                try:
+                    title = ''
+                    cls = data['container']['app_id']
+                except:
+                    pass
 
             if title == '' and cls == '':
                 continue


### PR DESCRIPTION
Sometimes in Sway, when an application goes from fullscreen to
windowed mode, there is neither a "app_id" or "window_properties"
attribute.  Avoid throwing an exception for this case.