### PR TITLE
keyd-application-mapper: Systemd user unit file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,12 @@ install:
 		echo "NOTE: systemd not found, you will need to manually add keyd to your system's init process."; \
 	fi
 
+	@if [ -e $(DESTDIR)$(PREFIX)/lib/systemd/user/ ]; then \
+		install -Dm644 keyd-application-mapper.service $(DESTDIR)$(PREFIX)/lib/systemd/user/keyd-application-mapper.service; \
+	else \
+		echo "NOTE: systemd user directory not found, keyd-applicaion-mapper.service not installed."; \
+	fi
+
 	@if [ -e $(DESTDIR)$(PREFIX)/share/libinput/ ]; then \
 		install -Dm644 keyd.quirks $(DESTDIR)$(PREFIX)/share/libinput/30-keyd.quirks; \
 	else \
@@ -75,6 +81,7 @@ install:
 uninstall:
 	rm -rf $(DESTDIR)$(PREFIX)/share/libinput/30-keyd.quirks \
 		$(DESTDIR)$(PREFIX)/lib/systemd/system/keyd.service \
+		$(DESTDIR)$(PREFIX)/lib/systemd/user/keyd-application-mapper.service \
 		$(DESTDIR)$(PREFIX)/bin/keyd \
 		$(DESTDIR)$(PREFIX)/bin/keyd-application-mapper \
 		$(DESTDIR)$(PREFIX)/share/doc/keyd/ \

--- a/README.md
+++ b/README.md
@@ -131,6 +131,15 @@ E.G
 
 You will probably want to put `keyd-application-mapper -d` somewhere in your 
 display server initialization logic (e.g ~/.xinitrc) unless you are running Gnome.
+If your computer is running systemd, you can start keyd-application-mapper
+automatically each login by enabling the supplied user service:
+
+	`systemctl --user enable keyd-application-mapper.service`
+
+After logging out and back in, the following command should show you if it
+is running:
+
+	`systemctl --user status keyd-application-mapper.service`
 
 See the man page for more details.
 

--- a/keyd-application-mapper.service
+++ b/keyd-application-mapper.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=keyd application specific mappings
+Documentation=man:keyd-application-mapper
+ConditionUser=!root
+
+[Service]
+ExecStart=keyd-application-mapper
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
Allow a user to start keyd-application-mapper automatically
each login session.

Example commands are shown below, to start the service, see
its operational status, and enable it for all future logins:

   $ systemctl --user start keyd-application-mapper.service
   $ systemctl --user status keyd-application-mapper.service
   $ systemctl --user enable keyd-application-mapper.service