### PR TITLE
Change example key from A to B to avoid confusion with an article A

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ following config:
 
 This overloads the capslock key to function as both escape (when tapped) and
 control (when held) and remaps all modifiers to 'oneshot' keys. Thus to produce
-the letter A you can now simply tap shift and then a instead of having to hold
+the letter B you can now simply tap shift and then b instead of having to hold
 it. Finally it remaps insert to S-insert (paste on X11).
 
 # FAQS

--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ esc = capslock
 
 4. See the man page (`man keyd`) for a more comprehensive description.
 
+5. In case the config is malformed, logs can be read with `sudo journalctl -e -u keyd`.
+
 *Note*: It is possible to render your machine unusable with a bad config file.
 Should you find yourself in this position, the special key sequence
 `backspace+escape+enter` should cause keyd to terminate.


### PR DESCRIPTION
I was confused reading this part, until realized that "a" was a key and not an article.

Edit1:
Also, I realized it is possible to read keyd output from system logs, so added a notion for that.

Edit2:
Not related to the PR itself, but now as I have a change to ask the dev, I would like to know that is there anything that should prevent mapping the print-screen button? For example, I have tried a config line `print = a`, but nothing seems to change, where others work, like `b = a`.  I guess I have the correct key name ("print"), as `xev -event keyboard` prints _"keycode 107 (keysym 0xff61, Print)"_ when I press it. 