### PR TITLE
Add example to docs about disabling specific keys

### DIFF
--- a/docs/keyd.scdoc
+++ b/docs/keyd.scdoc
@@ -890,6 +890,16 @@ keys. If tapped, it will function as escape.
 	l = right
 ```
 
+## Example 8
+
+Disable specific keyboard keys with 'noop'.
+
+```
+	[main]
+	esc = noop
+	end = noop
+```
+
 # AUTHOR
 
 Written by Raheman Vaiya (2017-).


### PR DESCRIPTION
Disabling specific keys is likely to be something people will want to do, however, the documentation doesn't emphasize that functionality. Add an example about disabling keys with the 'noop' keyword to the documentation to make it easier for users to figure out how to do that.

Closes #359