### PR TITLE
Update documentation: Binding Related

### DIFF
--- a/docs/keyd-application-mapper.scdoc
+++ b/docs/keyd-application-mapper.scdoc
@@ -27,7 +27,7 @@ Where _<filter>_ has one of the following forms:
 	\[<class exp>\]              # Match by window class
 	\[<class exp>|<title exp>\]  # Match by class and title
 
-and each _<expression>_ is a valid argument to _-e_ (see *Expressions*).
+and each _<expression>_ is a valid argument to _keyd bind_ (see *Bindings*).
 
 _<class exp>_ and _<title exp>_ are strings which describe window class and title names
 to be matched, and may optionally contain unix style wildcards (\*). For example,

--- a/docs/keyd.scdoc
+++ b/docs/keyd.scdoc
@@ -16,7 +16,7 @@ keyd(1)
 *listen*
 	Print layer state changes of the running keyd daemon to stdout. Useful for scripting.
 
-*bind <binding> [<binding>...]*
+*bind <binding> [reset] [<binding>...]*
 	Apply the supplied bindings. See _Bindings_ for details.
 
 *reload*
@@ -733,6 +733,14 @@ The _bind_ command accepts one or more _bindings_, each of which must have the f
 	\[<layer>.\]<key> = <key>|<macro>|<action>
 
 Where _<layer>_ is the name of an (existing) layer in which the key is to be bound.
+Available are user-configured layers and the following, default layers:
+
+	*main* - main layer++
+*control* - Control++
+*meta* - Meta/Super++
+*alt* - Alt++
+*shift* - Shift++
+*altgr* - AltGr
 
 As a special case, the string "reset" may be used in place of a binding, in
 which case the current keymap will revert to its original state (all


### PR DESCRIPTION
I have changed the description of layer in keyd-application-mapper and bind, etc.
I am not used to working with them, so there is a high possibility that they are incorrect.
You are free to change them as you like. Please leave a comment and I will fix it.

- Change reference to `keyd -e` to `keyd bind
- Add [reset] to COMMANDS:bind
- Add Describe the conditions of <layer> that can be used to *Bindings*
