### PR TITLE
Improve GNOME desktop environment detection

### DIFF
--- a/scripts/keyd-application-mapper
+++ b/scripts/keyd-application-mapper
@@ -40,6 +40,12 @@ def assert_env(var):
     if not os.getenv(var):
         raise Exception(f'Missing environment variable {var}')
 
+def assert_gnome():
+    if 'gnome' not in os.getenv('XDG_CURRENT_DESKTOP', '').lower() and \
+        not os.getenv('GNOME_SETUP_DISPLAY'):
+        raise Exception(f'Gnome desktop environment not detected by inspecting'
+            'XDG_CURRENT_DESKTOP and GNOME_SETUP_DISPLAY environment variables')
+
 def run(cmd):
     return subprocess.check_output(['/bin/sh', '-c', cmd]).decode('utf8')
 
@@ -253,7 +259,7 @@ class XMonitor():
 # :(
 class GnomeMonitor():
     def __init__(self, on_window_change):
-        assert_env('GNOME_SETUP_DISPLAY')
+        assert_gnome()
 
         self.on_window_change = on_window_change
 


### PR DESCRIPTION
In my environment (Pop!_OS 22.04 LTS, GNOME 42.5, X11) the GNOME_SETUP_DISPLAY environment variable is not set.

According to [this StackOverflow thread](https://tinyurl.com/2fyc8ssx) an alternative to detect GNOME would be to use XDG_CURRENT_DESKTOP.

I have confirmed that in my environment XDG_CURRENT_DESKTOP is set to `pop:GNOME`, hence the `assert_gnome()` logic.

I have confirmed that after the changes, keyd extension was installed (although not enabled) and keyd-application-mapper is working.