### PR TITLE
Fix macos.conf example

### DIFF
--- a/examples/macos.conf
+++ b/examples/macos.conf
@@ -58,7 +58,7 @@ right = end
 # As soon as tab is pressed (but not yet released), we switch to the
 # "app_switch_state" overlay where we can handle Meta-Backtick differently.
 # Also, send a 'M-tab' key tap before entering app_switch_sate.
-tab = swap(app_switch_state, M-tab)
+tab = swapm(app_switch_state, M-tab)
 
 # Meta-Backtick: Switch to next window in the application group
 # - A-f6 is the default binding for 'cycle-group' in gnome


### PR DESCRIPTION
swap() now needs to be swapm()  in recently changed hungarian function terminology.