### PR TITLE
Add gnome system modal awareness to keyd-application-mapper

### DIFF
--- a/scripts/keyd-application-mapper
+++ b/scripts/keyd-application-mapper
@@ -311,6 +311,7 @@ class GnomeMonitor():
         extension = '''
         const Shell = imports.gi.Shell;
         const GLib = imports.gi.GLib;
+        const Main = imports.ui.main;
 
         // We have to keep an explicit reference around to prevent garbage collection :/.
         let file = imports.gi.Gio.File.new_for_path('%s');
@@ -342,6 +343,13 @@ class GnomeMonitor():
 
                     send(`${cls}\\t${title}\\n`);
                 });
+
+                Main.layoutManager.connectObject(
+                    'system-modal-opened', () => {
+                        send(`system-modal\\t${global.stage.get_title()}\\n`);
+                    },
+                    this
+                );
 
                 return {
                     enable: ()=>{ GLib.spawn_command_line_async('keyd-application-mapper -d'); },


### PR DESCRIPTION
Allows `~/.config/keyd/app.conf` configurations to react to global system modal dialog. For example, the [pop-launcher](https://github.com/pop-os/launcher) is such a modal.

The pattern to match on is `system-modal`, e.g.

```
[system-modal]
ctrl_vim.k = C-k
ctrl_vim.j = C-j
```

There is some additional information called the "stage title" but its value is less reliable (it seems to always be "pop-shell" on my system).