### PR TITLE
Add a handler for SIGCHLD to prevent zombies

### DIFF
--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -369,8 +369,6 @@ static void execute_command(const char *cmd)
 
 	if (fork())
 		return;
-	if (fork())
-		exit(0);
 
 	fd = open("/dev/null", O_RDWR);
 
@@ -387,7 +385,7 @@ static void execute_command(const char *cmd)
 	dup2(fd, 1);
 	dup2(fd, 2);
 
-	execl("/bin/sh", "/bin/sh", "-c", cmd, NULL);
+	execl("/bin/sh", "/bin/sh", "-c", cmd, (char *) NULL);
 }
 
 static void clear_oneshot(struct keyboard *kbd)

--- a/src/keyd.c
+++ b/src/keyd.c
@@ -5,6 +5,7 @@
  */
 
 #include "keyd.h"
+#include "sys/wait.h"
 
 static int ipc_exec(int type, const char *data, size_t sz, uint32_t timeout)
 {
@@ -215,6 +216,16 @@ struct {
 	{"list-keys", "", "", list_keys},
 };
 
+void catch_child(int sig_num)
+{
+	int status;
+	wait(&status);
+	if (!WIFEXITED(status)) {
+		dbg("error running child process")
+	}
+}
+
+
 int main(int argc, char *argv[])
 {
 	size_t i;
@@ -227,6 +238,7 @@ int main(int argc, char *argv[])
 	signal(SIGTERM, exit);
 	signal(SIGINT, exit);
 	signal(SIGPIPE, SIG_IGN);
+	signal(SIGCHLD, catch_child);
 
 	if (argc > 1) {
 		for (i = 0; i < ARRAY_SIZE(commands); i++)


### PR DESCRIPTION
also removes an unneccesary `fork()`. Should fix https://github.com/rvaiya/keyd/issues/446. I think that the change cf0c45b doesn't actually help prevent zombies?