### PR TITLE
Add reference to `keyd monitor` in Quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ capslock = overload(control, esc)
 # Remaps the escape key to capslock
 esc = capslock
 ```
+*Note*: It is recommended that you define the input/output of the desired key, referring to the output of `keyd monitor`.
 
 3. Run `sudo keyd reload` to reload the config set.
 


### PR DESCRIPTION
I thought that by referring to the `keyd monitor`, we could avoid the initial confusion that non-US ANSI layout users may run into.
Sorry if this is unnecessary noise.