### PR TITLE
Add Fedora COPR package

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,10 @@ members, no personal responsibility is taken for them.
 
 [AUR](https://aur.archlinux.org/packages/keyd-git/) package maintained by eNV25.
 
+### Fedora
+
+[COPR](https://copr.fedorainfracloud.org/coprs/alternateved/keyd/) package maintained by [@alternateved](https://github.com/alternateved).
+
 # Sample Config
 
 	[ids]


### PR DESCRIPTION
Hello, thank you for a great tool!

I maintain a small Fedora [COPR repo](https://copr.fedorainfracloud.org/coprs/alternateved/keyd/) with keyd for my own usage. I thought that other people might benefit that it is already packaged for Fedora (via COPR) hence this small addition to README. 