### PR TITLE
Experimental hi-res scrolling

### DIFF
--- a/src/daemon.c
+++ b/src/daemon.c
@@ -438,10 +438,14 @@ static int event_handler(struct event *ev)
 				if (kbd->scroll.active) {
 					if (kbd->scroll.sensitivity == 0)
 						break;
-					int xticks, yticks;
+					const int scale = 10;
+					int scaled_y, scaled_x, xticks, yticks;
 
-					kbd->scroll.y += ev->devev->y;
-					kbd->scroll.x += ev->devev->x;
+					scaled_y = ev->devev->y << scale;
+					scaled_x = ev->devev->x << scale;
+
+					kbd->scroll.y += scaled_y;
+					kbd->scroll.x += scaled_x;
 
 					yticks = kbd->scroll.y / kbd->scroll.sensitivity;
 					kbd->scroll.y %= kbd->scroll.sensitivity;
@@ -449,8 +453,7 @@ static int event_handler(struct event *ev)
 					xticks = kbd->scroll.x / kbd->scroll.sensitivity;
 					kbd->scroll.x %= kbd->scroll.sensitivity;
 
-					vkbd_mouse_scroll(vkbd, 0, -1*yticks);
-					vkbd_mouse_scroll(vkbd, 0, xticks);
+					vkbd_mouse_scroll_hi_res(vkbd, xticks, -1 * yticks);
 				} else {
 					vkbd_mouse_move(vkbd, ev->devev->x, ev->devev->y);
 				}

--- a/src/vkbd.h
+++ b/src/vkbd.h
@@ -15,6 +15,7 @@ struct vkbd *vkbd_init(const char *name);
 void vkbd_mouse_move(const struct vkbd *vkbd, int x, int y);
 void vkbd_mouse_move_abs(const struct vkbd *vkbd, int x, int y);
 void vkbd_mouse_scroll(const struct vkbd *vkbd, int x, int y);
+void vkbd_mouse_scroll_hi_res(const struct vkbd *vkbd, int x, int y);
 
 void vkbd_send_key(const struct vkbd *vkbd, uint8_t code, int state);
 

--- a/src/vkbd/uinput.c
+++ b/src/vkbd/uinput.c
@@ -120,6 +120,8 @@ static int create_virtual_pointer(const char *name)
 	ioctl(fd, UI_SET_RELBIT, REL_X);
 	ioctl(fd, UI_SET_RELBIT, REL_WHEEL);
 	ioctl(fd, UI_SET_RELBIT, REL_HWHEEL);
+	ioctl(fd, UI_SET_RELBIT, REL_WHEEL_HI_RES);
+	ioctl(fd, UI_SET_RELBIT, REL_HWHEEL_HI_RES);
 	ioctl(fd, UI_SET_RELBIT, REL_Y);
 	ioctl(fd, UI_SET_RELBIT, REL_Z);
 
@@ -269,6 +271,35 @@ void vkbd_mouse_scroll(const struct vkbd *vkbd, int x, int y)
 
 	ev.type = EV_REL;
 	ev.code = REL_HWHEEL;
+	ev.value = x;
+
+	ev.time.tv_sec = 0;
+	ev.time.tv_usec = 0;
+
+	xwrite(vkbd->pfd, &ev, sizeof(ev));
+
+	ev.type = EV_SYN;
+	ev.code = 0;
+	ev.value = 0;
+
+	xwrite(vkbd->pfd, &ev, sizeof(ev));
+}
+
+void vkbd_mouse_scroll_hi_res(const struct vkbd *vkbd, int x, int y)
+{
+	struct input_event ev;
+
+	ev.type = EV_REL;
+	ev.code = REL_WHEEL_HI_RES;
+	ev.value = y;
+
+	ev.time.tv_sec = 0;
+	ev.time.tv_usec = 0;
+
+	xwrite(vkbd->pfd, &ev, sizeof(ev));
+
+	ev.type = EV_REL;
+	ev.code = REL_HWHEEL_HI_RES;
 	ev.value = x;
 
 	ev.time.tv_sec = 0;


### PR DESCRIPTION
This is an attempt to address the hi-res scrolling issue from https://github.com/rvaiya/keyd/issues/383#issuecomment-1551187833

The sensitivity parameter is now interpreted such that 1024 will scroll by the mouse move X/Y input units. Lower for faster scroll speed; higher for lower scroll speed.

There's still some kind of jitter or latency introduced that isn't present when keyd isn't running :( Scrolling is certainly nowhere near as smooth.

This also seems to break regular (low-res) scrolling.