### PR TITLE
Fix overload bug: <action> is inputted when an overload key is pressed in combination with a key that it is translated to the overloaded key code

### DIFF
--- a/src/keyboard.h
+++ b/src/keyboard.h
@@ -48,8 +48,7 @@ struct keyboard {
 	struct cache_entry cache[CACHE_SIZE];
 
 	uint8_t last_pressed_output_code;
-	uint8_t last_pressed_code;
-
+        uint8_t last_pressed_code; // the last translated and pressed key
 	uint8_t oneshot_latch;
 
 	uint8_t inhibit_modifier_guard;
@@ -66,7 +65,7 @@ struct keyboard {
 	long overload_start_time;
 
 	long timeouts[64];
-	size_t nr_timeouts; 
+	size_t nr_timeouts;
 
 	struct active_chord {
 		uint8_t active;

--- a/t/overload-same-key.t
+++ b/t/overload-same-key.t
@@ -1,0 +1,9 @@
+z down
+/ down
+/ up
+z up
+
+control down
+z down
+z up
+control up

--- a/t/test.conf
+++ b/t/test.conf
@@ -43,6 +43,8 @@ o = overloadt(control, a, 10)
 = = timeout(a, 300, b)
 \ = 😄
 [ = togglem(control, macro(one))
+z = overload(control, enter)
+/ = z
 
 [altgr]
 


### PR DESCRIPTION
Dramatis personae:
- `'` as `overload(control, enter)`.
- `q` as `'`.

Overload inputs the `<action>` argument when it is pressed with another key that it is translated to the code of the overload key. Currently, holding `'` and then pressing `q` (and the releasing the keys) would deactivate the control layer and would also output `enter`.

Notice that I added a test, run it without the `keyboard.c` modifications to see what I tried to explained.
