### PR TITLE
doc: add gtk4 warning

### DIFF
--- a/docs/keyd.scdoc
+++ b/docs/keyd.scdoc
@@ -410,6 +410,11 @@ layout and keyd's unicode functionality.
 normal way. If you want shift to produce a different symbol, you will need to
 define a custom shift layer (see the included layout files for an example).
 
+
+**Note 3:**
+known issue:
+/usr/share/keyd/keyd.compose is a significantly big file, and could make application using GTK4 as dependency crash
+
 ## Aliases
 
 Each key may optionally be assigned an *alias*. This alias may be used in place


### PR DESCRIPTION
GTK4 crash due to XCompose file beeing too long, https://github.com/rvaiya/keyd/issues/537
Add a warning in the doc