### PR TITLE
New Feature: Announce layout changes

### DIFF
--- a/src/daemon.c
+++ b/src/daemon.c
@@ -112,6 +112,11 @@ static void on_layer_change(const struct keyboard *kbd, const char *name, uint8_
 	write_msg(kbd, state ? '+' : '-', name);
 }
 
+static void on_layout_change(const struct keyboard *kbd, const char *name)
+{
+	write_msg(kbd, '/', name);
+}
+
 static void load_configs()
 {
 	DIR *dh = opendir(CONFIG_DIR);
@@ -142,6 +147,7 @@ static void load_configs()
 				struct output output = {
 					.send_key = send_key,
 					.on_layer_change = on_layer_change,
+					.on_layout_change = on_layout_change,
 				};
 				ent->kbd = new_keyboard(&ent->config, &output);
 

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -443,8 +443,9 @@ static void setlayout(struct keyboard *kbd, uint8_t idx)
 
 	kbd->layer_state[idx].activation_time = 1;
 	kbd->layer_state[idx].active = 1;
-}
 
+	kbd->output.on_layout_change(kbd, kbd->config.layers[idx].name);
+}
 
 static void schedule_timeout(struct keyboard *kbd, long timeout)
 {

--- a/src/keyboard.h
+++ b/src/keyboard.h
@@ -33,6 +33,7 @@ struct key_event {
 struct output {
 	void (*send_key) (uint8_t code, uint8_t state);
 	void (*on_layer_change) (const struct keyboard *kbd, const char *name, uint8_t active);
+	void (*on_layout_change) (const struct keyboard *kbd, const char *name);
 };
 
 /* May correspond to more than one physical input device. */

--- a/t/test-io.c
+++ b/t/test-io.c
@@ -222,6 +222,10 @@ static void on_layer_change(const struct keyboard *kbd, const char *name, uint8_
 {
 }
 
+static void on_layout_change(const struct keyboard *kbd, const char *name)
+{
+}
+
 int main(int argc, char *argv[])
 {
 	size_t i;
@@ -231,6 +235,7 @@ int main(int argc, char *argv[])
 	struct output output = {
 		.send_key = send_key,
 		.on_layer_change = on_layer_change,
+		.on_layout_change = on_layout_change,
 	};
 
 	if (argc < 2) {


### PR DESCRIPTION
When using several layouts (e.g. QWERTY and Colemak) on the same machine it is hard to track which one is currently active (e.g. to show in status bars). While layers are announced to listeners in `keyd listen`, the same is not true for layouts. This PR adds that and also sends the last active layout whenever a new listener is connected to always have the current state available.