### PR TITLE
Fix nav-layer.conf example

### DIFF
--- a/examples/nav-layer.conf
+++ b/examples/nav-layer.conf
@@ -1,6 +1,6 @@
 # Goal:
 #
-# To create a vi like navigation layer accessible by holding capslock while having capslock
+# To create a vi like navigation layer accessible by holding capslock while holding capslock
 # otherwise behave like the control key (when held) and escape when tapped.
 #
 # In essence we want:
@@ -27,42 +27,27 @@
 #  - capslock+shift+k = C-S-k
 #  ....
 
-# This is achieved by creating a 'nested layer' called [capslock_shift]
+# This is achieved by creating a composite layer called [capslock+shift]
 # which is activated whenever capslock and shift are simultaneously
 # held.
-#
-# The important bindings are:
-#
-# [shift]
-# capslock = layer(capslock_shift)
-#
-# [capslock]
-# shift = layer(capslock_shift)
+
 
 [ids]
-
 *
 
 [main]
-
 capslock = overload(capslock, esc)
 
-# The default shift layer (the layer activated when shift is pressed).
-[shift]
-
-capslock = layer(capslock_shift)
-
 [capslock:C]
-
-shift = layer(capslock_shift)
 h = left
 j = down
 k = up
 l = right
 
-[capslock_shift]
-
+# Activates when both capslock and shift is pressed
+[capslock+shift]
 h = C-left
 j = C-down
 k = C-up
 l = C-right
+


### PR DESCRIPTION
See https://github.com/rvaiya/keyd/issues/598

In short, the nav-layer.conf is outdated as it uses nested layers instead of the newer composite layer pattern to achieve binding to multiple modifier keys. This leads to odd behaviour when one of the modifiers is a Shift.

Credit goes to @nsbgn, this fix is from him: https://github.com/rvaiya/keyd/issues/598#issuecomment-1771081994