### PR TITLE
Reduce service dependencies

### DIFF
--- a/keyd.service.in
+++ b/keyd.service.in
@@ -1,11 +1,9 @@
 [Unit]
 Description=key remapping daemon
-Requires=local-fs.target
-After=local-fs.target
 
 [Service]
 Type=simple
 ExecStart=@PREFIX@/bin/keyd
 
 [Install]
-WantedBy=sysinit.target
+WantedBy=default.target


### PR DESCRIPTION
Since `/etc/keyd/` `/usr/bin/` etc. are root filesystems and are already available, the following are not required.

    Requires=local-fs.target
    After=local-fs.target

Similarly, the following is appropriate to replace `default.target` because it contains `local-fs.target` and so on as dependencies.

    WantedBy=sysinit.target