### PR TITLE
Reduce service dependencies

### DIFF
--- a/keyd.service.in
+++ b/keyd.service.in
@@ -6,4 +6,4 @@ Type=simple
 ExecStart=@PREFIX@/bin/keyd
 
 [Install]
-WantedBy=default.target
+WantedBy=multi-user.target

--- a/keyd.service.in
+++ b/keyd.service.in
@@ -1,11 +1,9 @@
 [Unit]
 Description=key remapping daemon
-Requires=local-fs.target
-After=local-fs.target
 
 [Service]
 Type=simple
 ExecStart=@PREFIX@/bin/keyd
 
 [Install]
-WantedBy=sysinit.target
+WantedBy=default.target


### PR DESCRIPTION
Since `/etc/keyd/` `/usr/bin/` etc. are root filesystems and are already available, the following are not required.

    Requires=local-fs.target
    After=local-fs.target

Similarly, the following dependencies include `local-fs.target`, etc., and it is appropriate to replace them with `default.target`.

    WantedBy=sysinit.target