### PR TITLE
Install extension for gnome-shell 45

### DIFF
--- a/scripts/keyd-application-mapper
+++ b/scripts/keyd-application-mapper
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import subprocess
 import argparse
@@ -294,77 +294,97 @@ class GnomeMonitor():
 
         self.on_window_change = on_window_change
 
-        self.version = '1.4'
+        self.version = '1.5'
         self.extension_dir = os.getenv('HOME') + '/.local/share/gnome-shell/extensions/keyd'
         self.fifo_path = self.extension_dir + '/keyd.fifo'
 
-    def _install(self):
+    def _install(self, gnome_shell_version):
         shutil.rmtree(self.extension_dir, ignore_errors=True)
         os.makedirs(self.extension_dir, exist_ok=True)
 
+        if gnome_shell_version < 45:
+            imports = '''
+const Shell = imports.gi.Shell;
+const GLib = imports.gi.GLib;
+const Gio = imports.gi.Gio;
+const Main = imports.ui.main;
+'''
+        else:
+            imports = '''
+import Shell from 'gi://Shell';
+import GLib from 'gi://GLib';
+import Gio from 'gi://Gio';
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+'''
+
         extension = '''
-        const Shell = imports.gi.Shell;
-        const GLib = imports.gi.GLib;
-        const Main = imports.ui.main;
+// We have to keep an explicit reference around to prevent garbage collection :/.
+let file = Gio.File.new_for_path('%s');
+let pipe = file.append_to_async(0, 0, null, on_pipe_open);
 
-        // We have to keep an explicit reference around to prevent garbage collection :/.
-        let file = imports.gi.Gio.File.new_for_path('%s');
-        let pipe = file.append_to_async(0, 0, null, on_pipe_open);
+function send(msg) {
+    if (!pipe)
+        return;
 
-        function send(msg) {
-            if (!pipe)
-                return;
+    try {
+        pipe.write(msg, null);
+    } catch {
+        log('pipe closed, reopening...');
+        pipe = null;
+        file.append_to_async(0, 0, null, on_pipe_open);
+    }
+}
 
-            try {
-                pipe.write(msg, null);
-            } catch {
-                log('pipe closed, reopening...');
-                pipe = null;
-                file.append_to_async(0, 0, null, on_pipe_open);
-            }
-        }
+function on_pipe_open(file, res) {
+    log('pipe opened');
+    pipe = file.append_to_finish(res);
+}
 
-        function on_pipe_open(file, res) {
-            log('pipe opened');
-            pipe = file.append_to_finish(res);
-        }
+function init() {
+    Shell.WindowTracker.get_default().connect('notify::focus-app', () => {
+        const win = global.display.focus_window;
+        const cls = win ? win.get_wm_class() : 'root';
+        const title = win ? win.get_title() : '';
 
-        function init() {
-                Shell.WindowTracker.get_default().connect('notify::focus-app', () => {
-                    const win = global.display.focus_window;
-                    const cls = win ? win.get_wm_class() : 'root';
-                    const title = win ? win.get_title() : '';
+        send(`${cls}\\t${title}\\n`);
+    });
 
-                    send(`${cls}\\t${title}\\n`);
-                });
+    Main.layoutManager.connectObject(
+        'system-modal-opened', () => {
+            send(`system-modal\\t${global.stage.get_title()}\\n`);
+        },
+        this
+    );
 
-                Main.layoutManager.connectObject(
-                    'system-modal-opened', () => {
-                        send(`system-modal\\t${global.stage.get_title()}\\n`);
-                    },
-                    this
-                );
+    return {
+        enable: ()=>{ GLib.spawn_command_line_async('keyd-application-mapper -d'); },
+        disable: ()=>{ GLib.spawn_command_line_async('pkill -f keyd-application-mapper'); }
+    };
+}
+''' % (self.fifo_path)
 
-                return {
-                    enable: ()=>{ GLib.spawn_command_line_async('keyd-application-mapper -d'); },
-                    disable: ()=>{ GLib.spawn_command_line_async('pkill -f keyd-application-mapper'); }
-                };
-
-        }
-        ''' % (self.fifo_path)
-
-        metadata = '''
-        {
-                "name": "keyd",
-                "description": "Used by keyd to obtain active window information.",
-                "uuid": "keyd",
-                "shell-version": [ "41", "42", "43" ]
-        }
-        '''
+        if gnome_shell_version < 45:
+            metadata = '''
+{
+    "name": "keyd",
+    "description": "Used by keyd to obtain active window information.",
+    "uuid": "keyd",
+    "shell-version": [ "41", "42", "43", "44" ]
+}
+'''
+        else:
+            metadata = '''
+{
+    "name": "keyd",
+    "description": "Used by keyd to obtain active window information.",
+    "uuid": "keyd",
+    "shell-version": [ "45" ]
+}
+'''
 
         open(self.extension_dir + '/version', 'w').write(self.version)
         open(self.extension_dir + '/metadata.json', 'w').write(metadata)
-        open(self.extension_dir + '/extension.js', 'w').write(extension)
+        open(self.extension_dir + '/extension.js', 'w').write(imports + extension)
         os.mkfifo(self.fifo_path)
 
     def _is_installed(self):
@@ -373,10 +393,21 @@ class GnomeMonitor():
         except:
             return False
 
+    def _get_gnome_shell_version(self):
+        output = run("gnome-shell --version")
+        version_match = re.search(r'GNOME Shell (\d+\.?\d*)', output)
+        if version_match:
+            gnome_shell_version = float(version_match.group(1))
+            return gnome_shell_version
+        else:
+            diel("Could not parse GNOME Shell version: " + output)
+
+
     def init(self):
         if not self._is_installed():
             print('keyd extension not found, installing...')
-            self._install()
+            gnome_shell_version = self._get_gnome_shell_version()
+            self._install(gnome_shell_version)
             run_or_die('gsettings set org.gnome.shell disable-user-extensions false');
 
             print('Success! Please restart Gnome and run this script one more time.')


### PR DESCRIPTION
Use `gnome-shell --version` command to determine gnome shell version, and change the JS import method for the gnome extension (as well as shell-version metadata) based on this data.

Currently, I seem to be getting an error that I don't understand: "extensionModule.default is not a constructor", in Gnome Extensions after installing and enabling the extension, so I'm putting this PR in "Draft" mode hoping to gather help.