### PR TITLE
Follow man page conventions

### DIFF
--- a/docs/keyd-application-mapper.scdoc
+++ b/docs/keyd-application-mapper.scdoc
@@ -1,10 +1,14 @@
 keyd-application-mapper(1)
 
-# USAGE
+# NAME
 
-keyd-application-mapper [-d]
+keyd-application-mapper - remap keys when window focus changes
 
-# OVERVIEW
+# SYNOPSIS
+
+*keyd-application-mapper* [*-d*]
+
+# DESCRIPTION
 
 A script which reads _~/.config/keyd/app.conf_ and applies the supplied
 bindings whenever a window with a matching class comes into focus.


### PR DESCRIPTION
The lintian utility (Debian's package lint tool) complains if a utility's man page doesn't start with a "NAME" section.

While I'm here, rename "USAGE" to "SYNOPSIS" and "OVERVIEW" to "DESCRIPTION" to match man-pages(7).