### PR TITLE
Accept tabs, in addition to spaces, as K/=/V ini config separators

### DIFF
--- a/src/ini.c
+++ b/src/ini.c
@@ -41,11 +41,12 @@ void parse_kvp(char *s, char **key, char **value)
 			else
 				*c = 0;
 
-			while (*++c == ' ');
+			while (*++c == ' ' || *c == '\t');
 
 			*value = c;
 			return;
 		case ' ':
+		case '\t':
 			if (!last_space)
 				last_space = c;
 			break;


### PR DESCRIPTION
I had attempted to write a tab-aligned config and it didn't work at all; took me a while to track this down.

I don't think(?) we currently accept ^I as a synonym for "tab", so no functional changes for existing users?