### PR TITLE
When ignoring a device, actually ignore it and exclude it from poll()

### DIFF
--- a/src/daemon.c
+++ b/src/daemon.c
@@ -222,6 +222,8 @@ static void manage_device(struct device *dev)
 		flags |= ID_MOUSE;
 
 	if ((ent = lookup_config_ent(dev->vendor_id, dev->product_id, flags))) {
+		dev->fd = abs(dev->fd);
+
 		if (device_grab(dev)) {
 			keyd_log("DEVICE: y{WARNING} Failed to grab %s\n", dev->path);
 			dev->data = NULL;
@@ -237,6 +239,7 @@ static void manage_device(struct device *dev)
 	} else {
 		dev->data = NULL;
 		device_ungrab(dev);
+		dev->fd = -abs(dev->fd);
 		keyd_log("DEVICE: r{ignoring} %04hx:%04hx  (%s)\n", 
 			  dev->vendor_id, dev->product_id, dev->name);
 	}


### PR DESCRIPTION
Even nominally-ignored devices still woke up keyd for every input, which isn't a great situation for mice

Now the ones we don't care about are turned negative:
```
ppoll([{fd=7, events=POLLIN}, {fd=9, events=POLLIN|POLLERR}, {fd=10, events=POLLIN|POLLERR}, {fd=-11}, {fd=12, events=POLLIN|POLLERR}, {fd=-13}, {fd=3, events=POLLIN|POLLERR}], 7, NULL, NULL, 0) = 1 ([{fd=9, revents=POLLIN}])
```
and unturned negative if a reload finds them matched again

Closes #658 