### PR TITLE
Allow custom CONFIG_DIR at build time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ COMMIT=$(shell git describe --no-match --always --abbrev=7 --dirty)
 VKBD=uinput
 PREFIX?=/usr/local
 
-CONFIG_DIR=/etc/keyd
+CONFIG_DIR?=/etc/keyd
 SOCKET_PATH=/var/run/keyd.socket
 
 CFLAGS:=-DVERSION=\"v$(VERSION)\ \($(COMMIT)\)\" \


### PR DESCRIPTION
### Motivation

Sometimes you can't (or don't want to) put configuration in `/etc` or other global locations, for example when using atomic distros (ostree-based Fedoras).

This tiny change allows optionally changing config location at build time.