### PR TITLE
readme: Update arch package location

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ members, no personal responsibility is taken for them.
 
 ### Arch
 
-[AUR](https://aur.archlinux.org/packages/keyd-git/) package maintained by [@eNV25](https://github.com/eNV25).
+[Arch Linux](https://archlinux.org/packages/extra/x86_64/keyd/) package maintained by Arch packagers.
 
 ### Fedora
 


### PR DESCRIPTION
This has been imported into Arch's [extra] repository.