### PR TITLE
match ids using device name

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -802,6 +802,11 @@ static void parse_id_section(struct config *config, struct ini_section *section)
 				config->ids[config->nr_ids].flags = ID_KEYBOARD | ID_MOUSE;
 
 				config->nr_ids++;
+			} else if (!strncmp(s, "name:", 5)) {
+				assert(config->nr_ids < ARRAY_SIZE(config->ids));
+				strcpy(config->ids[config->nr_ids].name, s + 5);
+
+				config->nr_ids++;
 			}
 			else {
 				warn("%s is not a valid device id", s);
@@ -958,7 +963,7 @@ int config_parse(struct config *config, const char *path)
 	return config_parse_string(config, content);
 }
 
-int config_check_match(struct config *config, uint16_t vendor, uint16_t product, uint8_t flags)
+int config_check_match(struct config *config, uint16_t vendor, uint16_t product, const char *name, uint8_t flags)
 {
 	size_t i;
 
@@ -969,6 +974,9 @@ int config_check_match(struct config *config, uint16_t vendor, uint16_t product,
 			} else if (config->ids[i].flags & flags) {
 				return 2;
 			}
+		}
+		if (!strcmp(config->ids[i].name, name)) {
+			return 2;
 		}
 	}
 

--- a/src/config.h
+++ b/src/config.h
@@ -123,6 +123,7 @@ struct config {
 		uint16_t product;
 		uint16_t vendor;
 		uint8_t flags;
+		char name[64];
 	} ids[64];
 
 
@@ -152,6 +153,6 @@ int config_parse(struct config *config, const char *path);
 int config_add_entry(struct config *config, const char *exp);
 int config_get_layer_index(const struct config *config, const char *name);
 
-int config_check_match(struct config *config, uint16_t vendor, uint16_t product, uint8_t flags);
+int config_check_match(struct config *config, uint16_t vendor, uint16_t product, const char *name, uint8_t flags);
 
 #endif

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -184,6 +184,7 @@ static void load_configs()
 
 static struct config_ent *lookup_config_ent(uint16_t vendor,
 					    uint16_t product,
+					    const char *name,
 					    uint8_t flags)
 {
 	struct config_ent *ent = configs;
@@ -191,7 +192,7 @@ static struct config_ent *lookup_config_ent(uint16_t vendor,
 	int rank = 0;
 
 	while (ent) {
-		int r = config_check_match(&ent->config, vendor, product, flags);
+		int r = config_check_match(&ent->config, vendor, product, name, flags);
 
 		if (r > rank) {
 			match = ent;
@@ -221,7 +222,7 @@ static void manage_device(struct device *dev)
 	if (dev->capabilities & (CAP_MOUSE|CAP_MOUSE_ABS))
 		flags |= ID_MOUSE;
 
-	if ((ent = lookup_config_ent(dev->vendor_id, dev->product_id, flags))) {
+	if ((ent = lookup_config_ent(dev->vendor_id, dev->product_id, dev->name, flags))) {
 		if (device_grab(dev)) {
 			keyd_log("DEVICE: y{WARNING} Failed to grab %s\n", dev->path);
 			dev->data = NULL;


### PR DESCRIPTION
Hi, I'd love to get some feedback for these changes.

This matches the device using it's name (instead of the product/vendor ids).

Purpose is that PS2 devices and evdev devices don't have a product/vendor id and I'd like to match those.