### PR TITLE
Update Makefile for usb-gadget

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ all:
 	-mkdir bin
 	cp scripts/keyd-application-mapper bin/
 	sed -e 's#@PREFIX@#$(PREFIX)#' keyd.service.in > keyd.service
+	sed -e 's#@PREFIX@#$(PREFIX)#' src/vkbd/usb-gadget.service.in > src/vkbd/usb-gadget.service
 	$(CC) $(CFLAGS) -O3 $(COMPAT_FILES) src/*.c src/vkbd/$(VKBD).c -lpthread -o bin/keyd $(LDFLAGS)
 debug:
 	CFLAGS="-g -Wunused" $(MAKE)
@@ -89,7 +90,7 @@ uninstall:
 		$(DESTDIR)$(PREFIX)/bin/keyd-usb-gadget.sh \
 		$(DESTDIR)$(PREFIX)/lib/systemd/system/keyd.service
 clean:
-	-rm -rf bin keyd.service
+	-rm -rf bin keyd.service src/vkbd/usb-gadget.service
 test:
 	@cd t; \
 	for f in *.sh; do \

--- a/src/vkbd/usb-gadget.md
+++ b/src/vkbd/usb-gadget.md
@@ -14,7 +14,7 @@ HID reports.
     git clone https://github.com/rvaiya/keyd
     cd keyd
     make VKBD=usb-gadget && sudo make install VKBD=usb-gadget
-    sudo systemctl enable usb-gadget && sudo systemctl start usb-gadget
+    sudo systemctl enable keyd-usb-gadget && sudo systemctl start keyd-usb-gadget
     sudo systemctl enable keyd && sudo systemctl start keyd
 
 The device should show up as` 1d6b:0104 Linux Foundation Multifunction Composite Gadget`

--- a/src/vkbd/usb-gadget.service.in
+++ b/src/vkbd/usb-gadget.service.in
@@ -8,7 +8,7 @@ After=systemd-modules-load.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=/bin/bash /usr/bin/keyd-usb-gadget.sh
+ExecStart=/bin/bash @PREFIX@/bin/keyd-usb-gadget.sh
 
 [Install]
 WantedBy=keyd.service


### PR DESCRIPTION
Path in usb-gadget.service was broken, I fixed it by adding PREFIX, like it's done for keyd.service. And updated Makefile clean rule and installation instructions as well.

Installation was tested and it worked. But the usb-gadget mode is bugged. I opened an issue (#726).