### PR TITLE
Suggested examples for common patterns.

### DIFF
--- a/examples/extend-layer.conf
+++ b/examples/extend-layer.conf
@@ -1,7 +1,8 @@
-# This example demonstrates how to implement a variant of the Extend layer.
-# Notice how you can pin the layer down with the space bar if you need to 
-# do complex operations using the fingers of both hands. Vim users might
-# prefer to bind left, down up and right to h, j, k and l respectively.
+# This example demonstrates how to implement a variant of the Extend layer. Notice how
+# you can pin the layer down with the space bar if you need to  do complex operations
+# using the fingers of both hands. Vim users might  prefer to bind left, down up and right
+# to h, j, k and l respectively.
+
 [ids]
 
 *

--- a/examples/extend-layer.conf
+++ b/examples/extend-layer.conf
@@ -1,0 +1,36 @@
+# This example demonstrates how to implement a variant of the Extend layer.
+# Notice how you can pin the layer down with the space bar if you need to 
+# do complex operations using the fingers of both hands. Vim users might
+# prefer to bind left, down up and right to h, j, k and l respectively.
+[ids]
+
+*
+
+[main]
+
+capslock = overload(extend, capslock)
+
+[extend]
+
+q = overload(alt, escape)
+y = pageup
+u = home
+i = up
+o = end
+p = insert
+a = leftcontrol
+s = leftshift
+d = leftmeta
+f = leftalt
+h = pagedown
+j = left
+k = down
+l = right
+semicolon = delete
+apostrophe = esc
+n = compose
+m = backspace
+comma = space
+dot = tab
+slash = enter
+space = overload(extend, capslock)

--- a/examples/home-row-mods.conf
+++ b/examples/home-row-mods.conf
@@ -1,0 +1,23 @@
+# This example demonstrates how to implement one of the variants of home row modifers.
+# Notice we use the oneshot shift pattern. This is important to prevent shifting errors caused by
+# the necessary delay with which characters are emitted under overloadt (on release, instead of on press).
+# It is not recommended to use home-row shift for typing for the same reason. Home row modifiers
+# are best suited for combinations (i.e., shortcuts).
+[ids]
+
+*
+
+[main]
+
+a = overloadt(control, a, 200)
+s = overloadt(shift, s, 200)
+d = overloadt(meta, d, 200)
+f = overloadt(alt, f, 200)
+j = overloadt(alt, j, 200)
+k = overloadt(meta, k, 200)
+l = overloadt(shift, l, 200)
+; = overloadt(control, ;, 200)
+v = overloadt(altgr, v, 200)
+m = overloadt(altgr, m, 200)
+leftshift = oneshot(shift)
+rightshift = oneshot(shift)

--- a/examples/home-row-mods.conf
+++ b/examples/home-row-mods.conf
@@ -1,8 +1,9 @@
 # This example demonstrates how to implement one of the variants of home row modifers.
-# Notice we use the oneshot shift pattern. This is important to prevent shifting errors caused by
-# the necessary delay with which characters are emitted under overloadt (on release, instead of on press).
-# It is not recommended to use home-row shift for typing for the same reason. Home row modifiers
-# are best suited for combinations (i.e., shortcuts).
+# Notice we use the one-shot-shift pattern. This is important to prevent shifting errors
+# caused by the necessary delay with which characters are emitted under overloadt (on
+# release, instead of on press). It is not recommended to use home-row shift for typing
+# for that reason. Home row modifiers are best suited for combinations (i.e., shortcuts).
+
 [ids]
 
 *

--- a/examples/layer-carousel.conf
+++ b/examples/layer-carousel.conf
@@ -1,12 +1,13 @@
-# This example demostrates how to implement a layer carousel by:
+# This example demostrates how to implement a layer carousel which behaves as follows:
 # - Hold space (numbers layer)
 # - Tap right shift (functions layer)
 # - Tap left shift (numbers layer)
 # - Tap left shift (symbols layer)
 # - Release space (main layer)
-# By using swap in our secondary layers, the layer held by space, as determined in the main layer, 
-# changes and remains until another swap takes place or the space bar is released and the main layer 
-# is brought forward again.
+# By using swap in our secondary layers, the layer held by space (as determined in the
+# main layer) is replaced and remains active until another swap takes place or the space 
+# is eventually released, which brings us back to the main layer.
+
 [ids]
 
 *

--- a/examples/layer-carousel.conf
+++ b/examples/layer-carousel.conf
@@ -1,0 +1,37 @@
+# This example demostrates how to implement a layer carousel by:
+# - Hold space (numbers layer)
+# - Tap right shift (functions layer)
+# - Tap left shift (numbers layer)
+# - Tap left shift (symbols layer)
+# - Release space (main layer)
+# By using swap in our secondary layers, the layer held by space, as determined in the main layer, 
+# changes and remains until another swap takes place or the space bar is released and the main layer 
+# is brought forward again.
+[ids]
+
+*
+
+[main]
+
+space = overloadt(numbers, space, 200)
+
+[numbers]
+
+a = 1
+# Other numbers here.
+leftshift = overload(shift, swap(symbols))
+rightshift = overload(shift, swap(functions))
+
+[functions]
+
+a = f1
+# Other functions here.
+leftshift = overload(shift, swap(numbers))
+rightshift = overload(shift, swap(symbols))
+
+[symbols]
+
+a = grave
+# Other symbols here.
+leftshift = overload(shift, swap(functions))
+rightshift = overload(shift, swap(numbers))

--- a/examples/shift-bar.conf
+++ b/examples/shift-bar.conf
@@ -11,4 +11,4 @@
 
 [shift]
 
-space = overloadt(shift, space)
+space = overloadt(shift, space, 200)

--- a/examples/shift-bar.conf
+++ b/examples/shift-bar.conf
@@ -2,8 +2,9 @@
 # 1. Holding shift
 # 2. Holding space
 # 3. Releasing shift
-# You can continue to type  with the fingers of both hands and then release the space-bar to exit the shift layer.
-# Consider this as an alternative to caps-word mode (see issue #711).
+# The space-bar will keep the shift layer active until your release it. The advanteage is
+# that you can type using the fingers of both hands freely. Consider it as an alternative
+# to caps-word mode (see issue #711).
 
 [ids]
 

--- a/examples/shift-bar.conf
+++ b/examples/shift-bar.conf
@@ -1,0 +1,14 @@
+# This example demostrates how to use the space-bar as a shift key by:
+# 1. Holding shift
+# 2. Holding space
+# 3. Releasing shift
+# You can continue to type  with the fingers of both hands and then release the space-bar to exit the shift layer.
+# Consider this as an alternative to caps-word mode (see issue #711).
+
+[ids]
+
+*
+
+[shift]
+
+space = overloadt(shift, space)

--- a/examples/simlayer.conf
+++ b/examples/simlayer.conf
@@ -1,0 +1,18 @@
+# This example demonstrates what is sometimes calle a simlayer: when the layer is activated,
+# if no action is taken within a specified period of time, another action takes place. This
+# can be used, for example, to preserve the repeat action of a key (backspace in this case)
+# that is being overloaded.
+#
+[ids]
+
+*
+
+[main]
+
+backspace = timeout(overload(shortcuts, backspace), 500, backspace)
+
+[shortcuts]
+
+1 = M-pageup
+2 = M-pagedown
+# Other shortcuts here.

--- a/examples/simlayer.conf
+++ b/examples/simlayer.conf
@@ -1,8 +1,8 @@
-# This example demonstrates what is sometimes calle a simlayer: when the layer is activated,
-# if no action is taken within a specified period of time, another action takes place. This
-# can be used, for example, to preserve the repeat action of a key (backspace in this case)
-# that is being overloaded.
-#
+# This example demonstrates what is sometimes called a simlayer: when the layer is
+# activated, if no action is taken within a specified period of time, another action
+# takes place. This can be used, for example, to preserve the repeat action of the key
+# that is being overloaded (backspace in this case).
+
 [ids]
 
 *


### PR DESCRIPTION
This PR consists of adding examples of practical implementations of common emerging patterns from the keyboard customization community. This contributions focuses on 5 of them:

1. [Home row modifiers](https://precondition.github.io/home-row-mods)
2. [Extend layer](https://colemakmods.github.io/ergonomic-mods/extend.html)
3. Shift-bar ([layer pinning](https://argenkiwi.medium.com/keyboard-layer-pinning-20aafede96e5), #711)
4. Layer carousel ([~back to home?~](https://youtu.be/8wZ8FRwOzhU?si=mFl9mZY0PJc8ANA3&t=331), #665)
5. [Simlayer](https://github.com/yqrashawn/GokuRakuJoudo/blob/master/tutorial.md#advance3)

Of course this is not an exhaustive list and the examples may not resonate with the maintainers, but the main intention here is to expand the examples to to increase engagement with the project while reducing the number of avoidable inquiries in the form of issues. Needless to say that I am open to feedback and criticism and have no emotional attachment to the content I have shared. Unilateral modifications or refusal of this PR will not be taken personally. :laughing:  