### PR TITLE
Added indicator_led option

### DIFF
--- a/docs/keyd.scdoc
+++ b/docs/keyd.scdoc
@@ -553,11 +553,24 @@ any of the following options:
 	*macro_repeat_timeout:* The time separating successive executions of a macro.
 	(default: 50)
 
-	*layer_indicator:* If set, this will turn the capslock light on whenever a layer is active.
+	*layer_indicator:* If set, this will turn the *indicator_led* light on whenever a layer is active.
 	Note: Some wayland compositors will aggressively toggle LED state rendering this option
 	unusable.
 
 	(default: 0)
+
+	*indicator_led:* If *layer_indicator* is set, this will determine what LED to use.
+    This option will accept ONLY these values, if anything else is passed this will default
+    to 1 (i.e. capslock)
+
+    0 = Numlock
+    1 = Capslock
+    2 = Scrolllock
+
+    Note: if you pass a string to this option the activated LED will be Numlock due to
+    how atoi() works
+
+	(default: 1)
 
 	*macro_sequence_timeout:* If set, this will add a timeout (*in
 	microseconds*) between each emitted key in a macro sequence. This is

--- a/src/config.c
+++ b/src/config.c
@@ -755,6 +755,17 @@ static void parse_global_section(struct config *config, struct ini_section *sect
 			config->macro_repeat_timeout = atoi(ent->val);
 		else if (!strcmp(ent->key, "layer_indicator"))
 			config->layer_indicator = atoi(ent->val);
+		else if (!strcmp(ent->key, "indicator_led")) {
+			switch (atoi(ent->val)) {
+				case 0:
+				case 1:
+				case 2:
+					config->indicator_led = atoi(ent->val);
+					break;
+				default:
+					config->indicator_led = 1;
+			}
+		}
 		else if (!strcmp(ent->key, "overload_tap_timeout"))
 			config->overload_tap_timeout = atoi(ent->val);
 		else
@@ -933,6 +944,7 @@ static void config_init(struct config *config)
 
 	config->macro_timeout = 600;
 	config->macro_repeat_timeout = 50;
+    config->indicator_led = 1;
 }
 
 int config_parse(struct config *config, const char *path)

--- a/src/config.h
+++ b/src/config.h
@@ -143,6 +143,7 @@ struct config {
 	long chord_hold_timeout;
 
 	uint8_t layer_indicator;
+	uint8_t indicator_led;
 	uint8_t disable_modifier_guard;
 	char default_layout[MAX_LAYER_NAME_LEN];
 };

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -110,7 +110,7 @@ static void on_layer_change(const struct keyboard *kbd, const struct layer *laye
 
 		for (i = 0; i < device_table_sz; i++)
 			if (device_table[i].data == kbd)
-				device_set_led(&device_table[i], 1, active_layers);
+				device_set_led(&device_table[i], kbd->config.indicator_led, active_layers);
 	}
 
 	if (!nr_listeners)


### PR DESCRIPTION
Made this pull request because it enables using other LEDs for indicating layer enabling so it avoids collisions with the actual lock state.