### PR TITLE
config: Allow `m:*` to specify all mouse ids at once

### DIFF
--- a/docs/keyd.scdoc
+++ b/docs/keyd.scdoc
@@ -86,6 +86,7 @@ or
 	[ids]
 
 	*
+	m:*
 	-<id 1>
 	-<id 2>
 	...
@@ -129,9 +130,9 @@ Note: All keyboards defined within a given config file will share the
 same state. This is useful for linking separate input devices together
 (e.g foot pedals).
 
-Note 2: The wildcard will only match devices which keyd identifies as keyboards.
+Note 2: The `*` wildcard will only match devices which keyd identifies as keyboards.
 keyd is also capable of *managing mice* (e.g to facilitate clearing
-of oneshot modifiers on click), but their ids must be explicitly listed.
+of oneshot modifiers on click). To match all mice, use `m:*`.
 
 Note 3: *Mouse support is currently experimental*, and is mostly confined to
 traditional mice (e.g touchpads). Adding some mice to

--- a/src/config.c
+++ b/src/config.c
@@ -773,6 +773,8 @@ static void parse_id_section(struct config *config, struct ini_section *section)
 
 		if (!strcmp(s, "*")) {
 			config->wildcard = 1;
+		} else if (!strcmp(s, "m:*")) {
+			config->wildcard_mouse = 1;
 		} else if (strstr(s, "m:") == s) {
 			assert(config->nr_ids < ARRAY_SIZE(config->ids));
 			config->ids[config->nr_ids].flags = ID_MOUSE;
@@ -962,6 +964,9 @@ int config_check_match(struct config *config, const char *id, uint8_t flags)
 		}
 	}
 
+	/* Only the `m:*` wildcard should match mice, not the default `*` wildcard. */
+	if (flags == ID_MOUSE)
+		return config->wildcard_mouse ? 1 : 0;
 	return config->wildcard ? 1 : 0;
 }
 

--- a/src/config.h
+++ b/src/config.h
@@ -119,6 +119,7 @@ struct config {
 	char aliases[256][32];
 
 	uint8_t wildcard;
+	uint8_t wildcard_mouse;
 	struct {
 		char id[64];
 		uint8_t flags;

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -199,11 +199,7 @@ static struct config_ent *lookup_config_ent(const char *id, uint8_t flags)
 		ent = ent->next;
 	}
 
-	/* The wildcard should not match mice. */
-	if (rank == 1 && (flags == ID_MOUSE))
-		return NULL;
-	else
-		return match;
+	return match;
 }
 
 static void manage_device(struct device *dev)
@@ -545,7 +541,7 @@ int run_daemon(int argc, char *argv[])
 	if (ipcfd < 0)
 		die("failed to create %s (another instance already running?)", SOCKET_PATH);
 
-	vkbd = vkbd_init(VKBD_NAME);
+	vkbd = vkbd_init(VKBD_NAME, VPTR_NAME);
 
 	setvbuf(stdout, NULL, _IOLBF, 0);
 	setvbuf(stderr, NULL, _IOLBF, 0);

--- a/src/device.c
+++ b/src/device.c
@@ -185,7 +185,7 @@ static int device_init(const char *path, struct device *dev)
 		dev->data = NULL;
 		dev->grabbed = 0;
 
-		dev->is_virtual = !strcmp(dev->name, VKBD_NAME);
+		dev->is_virtual = !strcmp(dev->name, VKBD_NAME) || !strcmp(dev->name, VPTR_NAME);
 		return 0;
 	} else {
 		close(fd);

--- a/src/keyd.h
+++ b/src/keyd.h
@@ -50,6 +50,7 @@
 
 #define ARRAY_SIZE(x) (int)(sizeof(x)/sizeof(x[0]))
 #define VKBD_NAME "keyd virtual keyboard"
+#define VPTR_NAME "keyd virtual pointer"
 
 enum event_type {
 	EV_DEV_ADD,

--- a/src/vkbd.h
+++ b/src/vkbd.h
@@ -10,7 +10,7 @@
 
 struct vkbd;
 
-struct vkbd *vkbd_init(const char *name);
+struct vkbd *vkbd_init(const char *kbd_name, const char *ptr_name);
 
 void vkbd_mouse_move(const struct vkbd *vkbd, int x, int y);
 void vkbd_mouse_move_abs(const struct vkbd *vkbd, int x, int y);

--- a/src/vkbd/uinput.c
+++ b/src/vkbd/uinput.c
@@ -225,13 +225,13 @@ static void write_key_event(const struct vkbd *vkbd, uint8_t code, int state)
 	pthread_mutex_unlock(&mtx);
 }
 
-struct vkbd *vkbd_init(const char *name)
+struct vkbd *vkbd_init(const char *kbd_name, const char *ptr_name)
 {
 	pthread_t tid;
 
 	struct vkbd *vkbd = calloc(1, sizeof vkbd);
-	vkbd->fd = create_virtual_keyboard(name);
-	vkbd->pfd = create_virtual_pointer("keyd virtual pointer");
+	vkbd->fd = create_virtual_keyboard(kbd_name);
+	vkbd->pfd = create_virtual_pointer(ptr_name);
 
 	return vkbd;
 }


### PR DESCRIPTION
Previously, each mouse input device had to be specified explicitly in the config file. Now, all mice can be specified at once using `m:*`. To avoid backwards compatibility issues, `*` retains its existing meaning of "all keyboard devices".

To avoid capturing our own mouse output, the virtual pointer device is now marked as virtual (previously only the virtual keyboard was marked as virtual).