### PR TITLE
Enable GNOME extension for v47

### DIFF
--- a/data/gnome-extension-45/metadata.json
+++ b/data/gnome-extension-45/metadata.json
@@ -2,6 +2,6 @@
 	"name": "keyd",
 	"description": "Used by keyd to obtain active window information.",
 	"uuid": "keyd",
-	"shell-version": [ "45", "46" ]
+	"shell-version": [ "45", "46", "47" ]
 }
 


### PR DESCRIPTION
The extension works fine in Gnome 47, just the json needs to be updated to allow it.