### PR TITLE
config: Increase the auxiliary descriptor limit again

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -113,7 +113,7 @@ struct config {
 	struct layer layers[MAX_LAYERS];
 
 	/* Auxiliary descriptors used by layer bindings. */
-	struct descriptor descriptors[256];
+	struct descriptor descriptors[512];
 	struct macro macros[256];
 	struct command commands[64];
 	char aliases[256][32];


### PR DESCRIPTION
Complex configurations still easily hit the descriptor limit.

See (#876)