### PR TITLE
Passthrough unknown key codes

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -187,7 +187,7 @@ static uint8_t lookup_keycode(const char *name)
 {
 	size_t i;
 
-	for (i = 0; i < 256; i++) {
+	for (i = 0; i < KEY_MAX; i++) {
 		const struct keycode_table_ent *ent = &keycode_table[i];
 
 		if (ent->name &&
@@ -200,7 +200,7 @@ static uint8_t lookup_keycode(const char *name)
 	return 0;
 }
 
-static struct descriptor *layer_lookup_chord(struct layer *layer, uint8_t *keys, size_t n)
+static struct descriptor *layer_lookup_chord(struct layer *layer, uint16_t *keys, size_t n)
 {
 	size_t i;
 
@@ -241,11 +241,11 @@ static int set_layer_entry(const struct config *config,
 		//TODO: Handle aliases
 		char *tok;
 		struct descriptor *ld;
-		uint8_t keys[ARRAY_SIZE(layer->chords[0].keys)];
+		uint16_t keys[ARRAY_SIZE(layer->chords[0].keys)];
 		size_t n = 0;
 
 		for (tok = strtok(key, "+"); tok; tok = strtok(NULL, "+")) {
-			uint8_t code = lookup_keycode(tok);
+			uint16_t code = lookup_keycode(tok);
 			if (!code) {
 				err("%s is not a valid key", tok);
 				return -1;
@@ -285,7 +285,7 @@ static int set_layer_entry(const struct config *config,
 		}
 
 		if (!found) {
-			uint8_t code;
+			uint16_t code;
 
 			if (!(code = lookup_keycode(key))) {
 				err("%s is not a valid key or alias", key);
@@ -481,7 +481,8 @@ exit:
 
 int parse_macro_expression(const char *s, struct macro *macro)
 {
-	uint8_t code, mods;
+	uint16_t code;
+	uint8_t mods;
 
 	#define ADD_ENTRY(t, d) do { \
 		if (macro->sz >= ARRAY_SIZE(macro->entries)) { \
@@ -543,7 +544,8 @@ static int parse_descriptor(char *s,
 	char *fn = NULL;
 	char *args[5];
 	size_t nargs = 0;
-	uint8_t code, mods;
+	uint16_t code;
+	uint8_t mods;
 	int ret;
 	struct macro macro;
 	struct command cmd;
@@ -804,7 +806,7 @@ static void parse_alias_section(struct config *config, struct ini_section *secti
 	size_t i;
 
 	for (i = 0; i < section->nr_entries; i++) {
-		uint8_t code;
+		uint16_t code;
 		struct ini_entry *ent = &section->entries[i];
 		const char *name = ent->val;
 
@@ -1025,4 +1027,3 @@ int config_add_entry(struct config *config, const char *exp)
 
 	return set_layer_entry(config, layer, keyname, &d);
 }
-

--- a/src/config.h
+++ b/src/config.h
@@ -54,7 +54,7 @@ enum op {
 };
 
 union descriptor_arg {
-	uint8_t code;
+	uint16_t code;
 	uint8_t mods;
 	int16_t idx;
 	uint16_t sz;
@@ -70,7 +70,7 @@ struct descriptor {
 };
 
 struct chord {
-	uint8_t keys[8];
+	uint16_t keys[8];
 	size_t sz;
 
 	struct descriptor d;
@@ -94,7 +94,7 @@ struct layer {
 	} type;
 
 	uint8_t mods;
-	struct descriptor keymap[256];
+	struct descriptor keymap[KEY_MAX];
 
 	struct chord chords[64];
 	size_t nr_chords;

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -10,7 +10,7 @@ static int ipcfd = -1;
 static struct vkbd *vkbd = NULL;
 static struct config_ent *configs;
 
-static uint8_t keystate[256];
+static uint8_t keystate[KEY_MAX];
 
 static int listeners[32];
 static size_t nr_listeners = 0;
@@ -39,14 +39,14 @@ static void clear_vkbd()
 {
 	size_t i;
 
-	for (i = 0; i < 256; i++)
+	for (i = 0; i < KEY_MAX; i++)
 		if (keystate[i]) {
 			vkbd_send_key(vkbd, i, 0);
 			keystate[i] = 0;
 		}
 }
 
-static void send_key(uint8_t code, uint8_t state)
+static void send_key(uint16_t code, uint8_t state)
 {
 	keystate[code] = state;
 	vkbd_send_key(vkbd, code, state);
@@ -290,7 +290,8 @@ static int input(char *buf, size_t sz, uint32_t timeout)
 		char s[2];
 
 		if (csz == 1) {
-			uint8_t code, mods;
+			uint16_t code;
+			uint8_t mods;
 			s[0] = (char)codepoint;
 			s[1] = 0;
 

--- a/src/device.c
+++ b/src/device.c
@@ -491,7 +491,8 @@ struct device_event *device_read_event(struct device *dev)
 				 && ev.code <= BTN_TOOL_QUADTAP);
 			else {
 				keyd_log("r{ERROR:} unsupported evdev code: 0x%x\n", ev.code);
-				return NULL;
+				/* passthrough the code unchanged; we won't be able to remap it
+				   but we can still send the input. */
 			}
 		}
 

--- a/src/device.h
+++ b/src/device.h
@@ -52,7 +52,7 @@ struct device_event {
 		DEV_REMOVED,
 	} type;
 
-	uint8_t code;
+	uint16_t code;
 	uint8_t pressed;
 	uint32_t x;
 	uint32_t y;

--- a/src/evloop.c
+++ b/src/evloop.c
@@ -8,7 +8,7 @@ static size_t nr_aux_fds = 0;
 struct device device_table[MAX_DEVICES];
 size_t device_table_sz;
 
-static void panic_check(uint8_t code, uint8_t pressed)
+static void panic_check(uint16_t code, uint8_t pressed)
 {
 	static uint8_t enter, backspace, escape;
 	switch (code) {

--- a/src/keyboard.h
+++ b/src/keyboard.h
@@ -18,20 +18,20 @@
 struct keyboard;
 
 struct cache_entry {
-	uint8_t code;
+	uint16_t code;
 	struct descriptor d;
 	int dl;
 	int layer;
 };
 
 struct key_event {
-	uint8_t code;
+	uint16_t code;
 	uint8_t pressed;
 	int timestamp;
 };
 
 struct output {
-	void (*send_key) (uint8_t code, uint8_t state);
+	void (*send_key) (uint16_t code, uint8_t state);
 	void (*on_layer_change) (const struct keyboard *kbd, const struct layer *layer, uint8_t active);
 };
 
@@ -47,8 +47,8 @@ struct keyboard {
 	 */
 	struct cache_entry cache[CACHE_SIZE];
 
-	uint8_t last_pressed_output_code;
-	uint8_t last_pressed_code;
+	uint16_t last_pressed_output_code;
+	uint16_t last_pressed_code;
 
 	uint8_t oneshot_latch;
 
@@ -56,7 +56,6 @@ struct keyboard {
 
 	struct macro *active_macro;
 	int active_macro_layer;
-	int overload_last_layer_code;
 
 	long macro_timeout;
 	long oneshot_timeout;
@@ -83,7 +82,7 @@ struct keyboard {
 		const struct chord *match;
 		int match_layer;
 
-		uint8_t start_code;
+		uint16_t start_code;
 		long last_code_time;
 
 		enum {
@@ -95,7 +94,7 @@ struct keyboard {
 	} chord;
 
 	struct {
-		uint8_t code;
+		uint16_t code;
 		uint8_t dl;
 		long expire;
 		long tap_expiry;
@@ -122,7 +121,7 @@ struct keyboard {
 		uint8_t oneshot_depth;
 	} layer_state[MAX_LAYERS];
 
-	uint8_t keystate[256];
+	uint8_t keystate[KEY_MAX];
 
 	struct {
 		int x;

--- a/src/keyd.c
+++ b/src/keyd.c
@@ -64,7 +64,7 @@ static int list_keys(int argc, char *argv[])
 {
 	size_t i;
 
-	for (i = 0; i < 256; i++) {
+	for (i = 0; i < KEY_MAX; i++) {
 		const char *altname = keycode_table[i].alt_name;
 		const char *shiftedname = keycode_table[i].shifted_name;
 		const char *name = keycode_table[i].name;

--- a/src/keys.c
+++ b/src/keys.c
@@ -15,7 +15,7 @@ const struct modifier modifiers[MAX_MOD] = {
 	{MOD_CTRL, KEYD_LEFTCTRL},
 };
 
-const struct keycode_table_ent keycode_table[256] = {
+const struct keycode_table_ent keycode_table[KEY_MAX] = {
 	[KEYD_ESC] = { "esc", "escape", NULL },
 	[KEYD_1] = { "1", NULL, "!" },
 	[KEYD_2] = { "2", NULL, "@" },
@@ -343,7 +343,7 @@ int parse_modset(const char *s, uint8_t *mods)
 	return 0;
 }
 
-int parse_key_sequence(const char *s, uint8_t *codep, uint8_t *modsp)
+int parse_key_sequence(const char *s, uint16_t *codep, uint8_t *modsp)
 {
 	const char *c = s;
 	size_t i;
@@ -378,7 +378,7 @@ int parse_key_sequence(const char *s, uint8_t *codep, uint8_t *modsp)
 		c += 2;
 	}
 
-	for (i = 0; i < 256; i++) {
+	for (i = 0; i < KEY_MAX; i++) {
 		const struct keycode_table_ent *ent = &keycode_table[i];
 
 		if (ent->name) {

--- a/src/keys.h
+++ b/src/keys.h
@@ -288,12 +288,14 @@ struct modifier {
 #define  KEYD_FN               		254
 #define  KEYD_MOUSE_FORWARD    		255
 
+/* input-event-codes.h; this is the same on both Linux and FreeBSD. */
+#define KEY_MAX 0x2ff
 #define KEY_NAME(code) (keycode_table[code].name ? keycode_table[code].name : "UNKNOWN")
 
 int parse_modset(const char *s, uint8_t *mods);
-int parse_key_sequence(const char *s, uint8_t *code, uint8_t *mods);
+int parse_key_sequence(const char *s, uint16_t *code, uint8_t *mods);
 
 extern const struct modifier modifiers[MAX_MOD];
-extern const struct keycode_table_ent keycode_table[256];
+extern const struct keycode_table_ent keycode_table[KEY_MAX];
 
 #endif

--- a/src/macro.c
+++ b/src/macro.c
@@ -21,7 +21,8 @@ int macro_parse(char *s, struct macro *macro)
 
 	macro->sz = 0;
 	for (tok = strtok(s, " "); tok; tok = strtok(NULL, " ")) {
-		uint8_t code, mods;
+		uint16_t code;
+		uint8_t mods;
 		size_t len = strlen(tok);
 
 		if (!parse_key_sequence(tok, &code, &mods)) {
@@ -55,7 +56,7 @@ int macro_parse(char *s, struct macro *macro)
 				int xcode;
 
 				if (chrsz == 1 && codepoint < 128) {
-					for (i = 0; i < 256; i++) {
+					for (i = 0; i < KEY_MAX; i++) {
 						const char *name = keycode_table[i].name;
 						const char *shiftname = keycode_table[i].shifted_name;
 
@@ -82,7 +83,7 @@ int macro_parse(char *s, struct macro *macro)
 	#undef ADD_ENTRY
 }
 
-void macro_execute(void (*output)(uint8_t, uint8_t),
+void macro_execute(void (*output)(uint16_t, uint8_t),
 		   const struct macro *macro, size_t timeout)
 {
 	size_t i;
@@ -95,7 +96,7 @@ void macro_execute(void (*output)(uint8_t, uint8_t),
 			size_t j;
 			uint16_t idx;
 			uint8_t codes[4];
-			uint8_t code, mods;
+			uint16_t code, mods;
 
 		case MACRO_HOLD:
 			if (hold_start == -1)
@@ -132,7 +133,7 @@ void macro_execute(void (*output)(uint8_t, uint8_t),
 			mods = ent->data >> 8;
 
 			for (j = 0; j < ARRAY_SIZE(modifiers); j++) {
-				uint8_t code = modifiers[j].key;
+				uint16_t code = modifiers[j].key;
 				uint8_t mask = modifiers[j].mask;
 
 				if (mods & mask)
@@ -146,7 +147,7 @@ void macro_execute(void (*output)(uint8_t, uint8_t),
 			output(code, 0);
 
 			for (j = 0; j < ARRAY_SIZE(modifiers); j++) {
-				uint8_t code = modifiers[j].key;
+				uint16_t code = modifiers[j].key;
 				uint8_t mask = modifiers[j].mask;
 
 				if (mods & mask)

--- a/src/macro.h
+++ b/src/macro.h
@@ -27,7 +27,7 @@ struct macro {
 };
 
 
-void macro_execute(void (*output)(uint8_t, uint8_t),
+void macro_execute(void (*output)(uint16_t, uint8_t),
 		   const struct macro *macro,
 		   size_t timeout);
 

--- a/src/monitor.c
+++ b/src/monitor.c
@@ -48,7 +48,7 @@ int event_handler(struct event *ev)
 	case EV_DEV_EVENT:
 		switch (ev->devev->type) {
 		case DEV_KEY:
-			name = keycode_table[ev->devev->code].name;
+			name = KEY_NAME(ev->devev->code);
 
 			if (time_flag && last_time)
 				keyd_log("r{+%ld} ms\t", ev->timestamp - last_time);

--- a/src/vkbd.h
+++ b/src/vkbd.h
@@ -16,7 +16,7 @@ void vkbd_mouse_move(const struct vkbd *vkbd, int x, int y);
 void vkbd_mouse_move_abs(const struct vkbd *vkbd, int x, int y);
 void vkbd_mouse_scroll(const struct vkbd *vkbd, int x, int y);
 
-void vkbd_send_key(const struct vkbd *vkbd, uint8_t code, int state);
+void vkbd_send_key(const struct vkbd *vkbd, uint16_t code, int state);
 
 void free_vkbd(struct vkbd *vkbd);
 #endif

--- a/src/vkbd/stdout.c
+++ b/src/vkbd/stdout.c
@@ -39,7 +39,7 @@ void vkbd_mouse_move_abs(const struct vkbd *vkbd, int x, int y)
 
 void vkbd_send_key(const struct vkbd *vkbd, uint8_t code, int state)
 {
-	printf("key: %s, state: %d\n", keycode_table[code].name, state);
+	printf("key: %s, state: %d\n", KEY_NAME(code), state);
 }
 
 void free_vkbd(struct vkbd *vkbd)

--- a/src/vkbd/stdout.c
+++ b/src/vkbd/stdout.c
@@ -37,7 +37,7 @@ void vkbd_mouse_move_abs(const struct vkbd *vkbd, int x, int y)
 	printf("absolute mouse movement: x: %d, y: %d\n", x, y);
 }
 
-void vkbd_send_key(const struct vkbd *vkbd, uint8_t code, int state)
+void vkbd_send_key(const struct vkbd *vkbd, uint16_t code, int state)
 {
 	printf("key: %s, state: %d\n", KEY_NAME(code), state);
 }

--- a/src/vkbd/uinput.c
+++ b/src/vkbd/uinput.c
@@ -64,7 +64,7 @@ static int create_virtual_keyboard(const char *name)
 		exit(-1);
 	}
 
-	for (code = 0; code < 256; code++) {
+	for (code = 0; code < KEY_MAX; code++) {
 		if (keycode_table[code].name) {
 			if (ioctl(fd, UI_SET_KEYBIT, code)) {
 				perror("ioctl set_keybit");
@@ -157,7 +157,7 @@ static int create_virtual_pointer(const char *name)
 	return fd;
 }
 
-static void write_key_event(const struct vkbd *vkbd, uint8_t code, int state)
+static void write_key_event(const struct vkbd *vkbd, uint16_t code, int state)
 {
 	static pthread_mutex_t mtx = PTHREAD_MUTEX_INITIALIZER;
 	struct input_event ev;
@@ -331,7 +331,7 @@ void vkbd_mouse_move_abs(const struct vkbd *vkbd, int x, int y)
 	xwrite(vkbd->pfd, &ev, sizeof(ev));
 }
 
-void vkbd_send_key(const struct vkbd *vkbd, uint8_t code, int state)
+void vkbd_send_key(const struct vkbd *vkbd, uint16_t code, int state)
 {
 	dbg("output %s %s", KEY_NAME(code), state == 1 ? "down" : "up");
 

--- a/src/vkbd/usb-gadget.c
+++ b/src/vkbd/usb-gadget.c
@@ -149,7 +149,7 @@ void vkbd_mouse_scroll(const struct vkbd *vkbd, int x, int y)
 	fprintf(stderr, "usb-gadget: mouse support is not implemented\n");
 }
 
-void vkbd_send_key(const struct vkbd *vkbd, uint8_t code, int state)
+void vkbd_send_key(const struct vkbd *vkbd, uint16_t code, int state)
 {
 	if (update_modifier_state(code, state) < 0)
 		update_key_state(code, state);

--- a/src/vkbd/usb-gadget.h
+++ b/src/vkbd/usb-gadget.h
@@ -19,7 +19,7 @@
 #define HID_RIGHTSUPER 0x80
 #define HID_SUPER 0x8
 
-static const uint8_t hid_table[256] = {
+static const uint8_t hid_table[KEY_MAX] = {
 	[KEYD_ESC] = 0x29,
 	[KEYD_1] = 0x1e,
 	[KEYD_2] = 0x1f,

--- a/t/test-io.c
+++ b/t/test-io.c
@@ -35,7 +35,7 @@ static uint8_t lookup_code(const char *name)
 	return 0;
 }
 
-static void send_key(uint8_t code, uint8_t pressed)
+static void send_key(uint16_t code, uint8_t pressed)
 {
 	output[noutput].code = code;
 	output[noutput].pressed = pressed;
@@ -170,7 +170,7 @@ static int parse_events(char *s, struct key_event in[MAX_EVENTS], size_t *nin,
 		if (len >= 2 && line[len - 1] == 's' && line[len - 2] == 'm') {
 			time += atoi(line);
 		} else {
-			uint8_t code;
+			uint16_t code;
 			char *k = strtok(line, " ");
 			char *v = strtok(NULL, " \n");
 


### PR DESCRIPTION
Currently, except for [a few select mouse buttons](https://github.com/rvaiya/keyd/blob/master/src/device.c#L469-L496), keyd does not support remapping keys with an event code higher than 256. This is reasonable and I don't propose changing it. However, right now it discards all keys that it doesn't know how to remap. That's not ideal and it prevents using keyd with arbitrary USB devices.

This does two things:
- Passes through unknown event codes without modifying them.
- Changes the internal representation of keycodes from `uint8_t` to `uint16_t`. Otherwise, we simply can't store the keycodes, they wrap around.

I tested this with a [Forty4 GC201 game controller](https://manuals.plus/m/035856a2b60f0d19e850f0d3b8c8a6631cb5b42f919c5eea42ef7439a60a9b9f_optim.pdf) and Celeste through Steam; before this change it did not register any inputs, and afterwards it works fine.

cc https://github.com/rvaiya/keyd/pull/842#issuecomment-2552407286, hopefully this addresses some of your concerns there.