### PR TITLE
Additional chromeos key mappings

### DIFF
--- a/examples/chromebook-linux.conf
+++ b/examples/chromebook-linux.conf
@@ -52,3 +52,14 @@ f7 = C-A-f7
 f8 = C-A-f8
 f9 = C-A-f9
 f10 = C-A-f10
+left = home
+right = end
+
+[control+alt]
+up = home
+down = end
+
+[alt]
+backspace = delete
+up = pageup
+down = pagedown


### PR DESCRIPTION
(From my comment in #573)

The documentation can be found here: https://support.google.com/chromebook/answer/183101?hl=en

Text editing / Delete the next letter (forward delete): Alt + Backspace
Page & web browser / Page up : Alt + Up arrow
Page & web browser / Page down : Alt + Down arrow
Page & web browser / Go to top of page: Ctrl + Alt + Up arrow
Page & web browser / Go to bottom of page: Ctrl + Alt + Down arrow