### PR TITLE
fix: do not panic on overload+enter+backspace

### DIFF
--- a/src/evloop.c
+++ b/src/evloop.c
@@ -104,7 +104,7 @@ int evloop(int (*event_handler) (struct event *ev))
 						break;
 					} else {
 						//Handle device event
-						if (!dev->is_virtual)
+						if (!dev->is_virtual && devev->type != DEV_LED)
 							panic_check(devev->code, devev->pressed);
 
 						ev.type = EV_DEV_EVENT;


### PR DESCRIPTION
Overloaded keys seem to send a `KEYD_ESC` keystroke some time after the overloaded key is pressed.

Overloading the `enter` key will trigger a panic when one presses `enter+backspace` (which should instead send `overloadedMod+backspace`).

The `KEYD_ESC` sent due to the overload has a `DEV_LED` type, so this is what I am using to avoid `panic`king, but maybe the appropriate solution is different (e.g., changing the artificial `KEYD_ESC` event to have `dev->is_virtual == 1`), but I am not familiar enough with the codebase to tell.  Please advise.