### PR TITLE
Allow using keyd-application mapper in autostart on kde wayland

### DIFF
--- a/scripts/keyd-application-mapper
+++ b/scripts/keyd-application-mapper
@@ -140,7 +140,7 @@ class KDE():
 
         bus = dbus.SessionBus()
 
-        kwin = bus.get_object('org.kde.KWin', '/Scripting')
+        kwin = KDE.get_kwin(bus)
 
         kwin.unloadScript(f.name)
         num = kwin.loadScript(f.name)
@@ -152,6 +152,20 @@ class KDE():
 
         script = bus.get_object('org.kde.KWin',  script_object)
         script.run()
+
+    @staticmethod
+    def get_kwin(bus):
+        import dbus
+        import time
+
+        last_err = None
+        for _ in range(5):
+            try:
+                return bus.get_object('org.kde.KWin', '/Scripting')
+            except dbus.exceptions.DBusException as e:
+                time.sleep(1)
+                last_err = e
+        if last_err is not None: raise last_err
 
     def run(self):
         import dbus.service


### PR DESCRIPTION
On KDE Wayland the script crashes with this exception if put in autostart because the dbus hasn't been owned yet (I think)
so we need to retry a few times and wait until it is ready
(note: the line numbers are slightly wrong because the version I logged the error from is different, however I tested it on the newest master branch and the error is the same)
```
Traceback (most recent call last):
  File "/usr/lib64/python3.13/site-packages/dbus/bus.py", line 173, in activate_name_owner
    return self.get_name_owner(bus_name)
           ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "/usr/lib64/python3.13/site-packages/dbus/bus.py", line 348, in get_name_owner
    return self.call_blocking(BUS_DAEMON_NAME, BUS_DAEMON_PATH,
           ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                              BUS_DAEMON_IFACE, 'GetNameOwner',
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                              's', (bus_name,))
                              ^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.13/site-packages/dbus/connection.py", line 634, in call_blocking
    reply_message = self.send_message_with_reply_and_block(
        message, timeout)
dbus.exceptions.DBusException: org.freedesktop.DBus.Error.NameHasNoOwner: The name does not have an owner

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/bin/keyd-application-mapper", line 146, in init
    kwin = bus.get_object('org.kde.KWin', '/Scripting')
  File "/usr/lib64/python3.13/site-packages/dbus/bus.py", line 237, in get_object
    return self.ProxyObjectClass(self, bus_name, object_path,
           ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                                 introspect=introspect,
                                 ^^^^^^^^^^^^^^^^^^^^^^
                                 follow_name_owner_changes=follow_name_owner_changes)
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.13/site-packages/dbus/proxies.py", line 250, in __init__
    self._named_service = conn.activate_name_owner(bus_name)
                          ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "/usr/lib64/python3.13/site-packages/dbus/bus.py", line 178, in activate_name_owner
    self.start_service_by_name(bus_name)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "/usr/lib64/python3.13/site-packages/dbus/bus.py", line 273, in start_service_by_name
    return (True, self.call_blocking(BUS_DAEMON_NAME, BUS_DAEMON_PATH,
                  ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                                     BUS_DAEMON_IFACE,
                                     ^^^^^^^^^^^^^^^^^
                                     'StartServiceByName',
                                     ^^^^^^^^^^^^^^^^^^^^^
                                     'su', (bus_name, flags)))
                                     ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.13/site-packages/dbus/connection.py", line 634, in call_blocking
    reply_message = self.send_message_with_reply_and_block(
        message, timeout)
dbus.exceptions.DBusException: org.freedesktop.DBus.Error.ServiceUnknown: The name is not activatable
```