### PR TITLE
add colemak_dh layout

### DIFF
--- a/layouts/colemak_dh
+++ b/layouts/colemak_dh
@@ -1,0 +1,35 @@
+[colemak_dh:layout]
+
+w = w
+, = ,
+s = r
+a = a
+c = c
+g = g
+q = q
+e = f
+] = ]
+d = s
+/ = /
+; = o
+' = '
+r = p
+f = t
+t = b
+u = l
+. = .
+j = n
+k = e
+p = ;
+o = y
+z = z
+h = m
+i = u
+[ = [
+v = d
+l = i
+m = h
+n = k
+x = x
+b = v
+y = j


### PR DESCRIPTION
adds a layout for colemak_dh [as described here](https://colemakmods.github.io/mod-dh/)
aka colemak_dh_ortho (zxc same as qwerty)
diff with colemak:
```bash
< [colemak:layout]
> [colemak_dh:layout]
< g = d
> g = g
< t = g
> t = b
< h = h
> h = m
< v = v
> v = d
< m = m
> m = h
< b = b
> b = v
```