### PR TITLE
add KEY_POWER as a "media key"

### DIFF
--- a/src/device.c
+++ b/src/device.c
@@ -62,6 +62,7 @@ static uint8_t resolve_device_capabilities(int fd, uint32_t *num_keys, uint8_t *
 		KEY_TOUCHPAD_TOGGLE,
 		KEY_TOUCHPAD_OFF,
 		KEY_MICMUTE,
+		KEY_POWER,
 	};
 	const uint32_t keyboard_keys[] = {
 		KEY_1, KEY_2, KEY_3, KEY_4,


### PR DESCRIPTION
Maybe this is too niche, but I would like to treat my power button as an extra key that I can remap.

My specific application is that I have a Framework 13 laptop, which has a very low-quality touchpad with buttons that don't work and no replacement options, and a power button with a bright glowing border that encourages young children to press it. Because of the children, I had to disable its "turn off the computer" functionality, and because of the bad touchpad, I was on the hunt for unused hard-to-hit-accidentally buttons to remap to middle-click-paste.