### PR TITLE
Use `mlockall` and `SCHED_RR`

### DIFF
--- a/src/keyd.h
+++ b/src/keyd.h
@@ -25,11 +25,21 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/un.h>
+#include <sys/resource.h>
+#include <sys/mman.h>
 #include <termios.h>
 #include <getopt.h>
 #include <errno.h>
 #include <time.h>
 #include <unistd.h>
+
+#ifdef _POSIX_PRIORITY_SCHEDULING
+	#ifdef __linux__
+		#include <linux/sched.h>
+	#else
+		#include <sched.h>
+	#endif
+#endif
 
 #ifdef __FreeBSD__
 	#include <dev/evdev/input.h>


### PR DESCRIPTION
Just before entering the event loop, `keyd` will attempt to give itself `SCHED_RR` with priority 25 or below (so long as it's not already `SCHED_RR` or `SCHED_FIFO`, as may be the case if the user has configured real-time scheduling for `keyd` via their service manager), raise its page locking soft resource limit to the corresponding hard limit, and call `mlockall(MCL_CURRENT | MCL_FUTURE)` to avoid having any part of it get swapped out. If `mlockall` fails, `keyd` will fail to start, much like it did (and does) if `nice(-20)` returns an error. `SCHED_RR` failure gets reported but is not considered critical.

The `SCHED_RR` part is necessary because nice -20 processes can easily get starved at the initiative of completely unprivileged processes which themselves have nice 0 by way of filesystem compression threads, such as those of Btrfs or ZFS. (Btrfs set its kthreads to nice -20 first and other filesystems followed suit, presumably to avoid pointless differences in behavior.) Also, allowing people who accidentally starved most processes by setting something to nice -20 (a game, I bet) to still use their keyboard is helpful.

The choice of priority 25 for `SCHED_RR` lands `keyd` above PipeWire data loop threads (priority 20) but below things like `lactd` (priority 30) and IRQ kthreads (priority 50).

The `mlockall` part is necessary because physical memory starvation and the ensuing swap hell can easily lock up `keyd` and likewise prevent the user from using their keyboard. (Wine prefix configuration update inexplicably fork-bombed my system yesterday and I couldn't even use magic SysRq to shut down my PC cleanly.)