### PR TITLE
Fix "incompatible pointer type" build error on Debian testing (gcc 14.3)

### DIFF
--- a/src/keyd.c
+++ b/src/keyd.c
@@ -203,7 +203,7 @@ static int layer_listen(int argc, char *argv[])
 	}
 }
 
-static int reload()
+static int reload(int argc, char *argv[])
 {
 	ipc_exec(IPC_RELOAD, NULL, 0, 0);
 


### PR DESCRIPTION
Fixes:

    src/keyd.c:232:28: error: initialization of 'int (*)(int,  char **)' from incompatible pointer type 'int (*)(void)' [-Wincompatible-pointer-types]
      232 |         {"reload", "", "", reload},
          |                            ^~~~~~
    src/keyd.c:232:28: note: (near initialization for 'commands[8].fn')
    src/keyd.c:206:12: note: 'reload' declared here
      206 | static int reload()
          |            ^~~~~~

See https://github.com/rhansen/keyd/commit/nullary for background.