### PR TITLE
Fix extra argument to `ipc_create_server()`

### DIFF
--- a/src/daemon.c
+++ b/src/daemon.c
@@ -611,7 +611,7 @@ static int event_handler(struct event *ev)
 
 int run_daemon(int argc, char *argv[])
 {
-	ipcfd = ipc_create_server(SOCKET_PATH);
+	ipcfd = ipc_create_server();
 	if (ipcfd < 0)
 		die("failed to create %s (another instance already running?)", SOCKET_PATH);
 


### PR DESCRIPTION
Fixes:

    src/daemon.c: In function 'run_daemon':
    src/daemon.c:614:17: error: too many arguments to function 'ipc_create_server'; expected 0, have 1
      614 |         ipcfd = ipc_create_server(SOCKET_PATH);
          |                 ^~~~~~~~~~~~~~~~~
    In file included from src/daemon.c:1:
    src/keyd.h:102:5: note: declared here
      102 | int ipc_create_server();
          |     ^~~~~~~~~~~~~~~~~

See https://github.com/rhansen/keyd/commit/nullary for background.