### PR TITLE
Add example mapping to fix Apple Magic Keyboard with Touch ID (MXCK3LL)

### DIFF
--- a/examples/apple-magic-keyboard-touch-id.conf
+++ b/examples/apple-magic-keyboard-touch-id.conf
@@ -1,0 +1,45 @@
+# The latest Apple Magic Keyboard with Touch ID (Model MXCK3LL) is currently not properly supported by hid_apple or any similar Linux kernel module.
+# This keyd configuration makes it supported and fixes the following problems:
+# 1. Properly map the Function (fn) key on the bottom left of the keyboard, which for some reason is by default understood as "brightness down" (???)
+# 2. Make all the media keys work properly (F3 and F4 are commented out by default, see below for details, you may need to adjust them before uncommenting if you're not using KDE.)
+# 3. Make Meta+Backspace function as Delete, which is very useful since Mac keyboards do not have a Delete key, and many keyboard shortcuts in Linux require a Delete key.
+# 4. Make fn+F# work as that particular F-key.
+
+[ids]
+# By default, target all devices. Add your device ID here to restrict to just the Apple Magic Keyboard.
+# You can get device IDs by running `sudo keyd monitor`.
+# A device ID looks like this: 0011:2233:44556677
+*
+
+[main]
+brightnessdown = overload(fn, fn)
+f1 = brightnessdown
+f2 = brightnessup
+# On KDE, this gives you "Window Overview", which is roughly equivalent. Adjust accordingly before uncommenting:
+# f3 = M-w
+# ON KDE, this gives you Krunner, which is roughly equivalent to Spotlight. Adjust accordingly before uncommenting:
+# f4 = A-space (.)
+f5 = micmute
+f7 = previoussong
+f8 = playpause
+f9 = nextsong
+f10 = mute
+f11 = volumedown
+f12 = volumeup
+
+[meta]
+backspace = delete
+
+[fn]
+f1 = f1
+f2 = f2
+f3 = f3
+f4 = f4
+f5 = f5
+f6 = f6
+f7 = f7
+f8 = f8
+f9 = f9
+f10 = f10
+f11 = f11
+f12 = f12


### PR DESCRIPTION
The latest Apple Magic Keyboard with Touch ID (Model MXCK3LL) is currently not properly supported by hid_apple or any similar Linux kernel module. This keyd configuration makes it supported and fixes the following problems:

1. Properly map the Function (fn) key on the bottom left of the keyboard, which for some reason is by default understood as "brightness down" (???)
2. Make all the media keys work properly (F3 and F4 are commented out by default, see below for details, you may need to adjust them before uncommenting if you're not using KDE.)
3. Make Meta+Backspace function as Delete, which is very useful since Mac keyboards do not have a Delete key, and many keyboard shortcuts in Linux require a Delete key.
4. Make fn+F# work as that particular F-key.

This mapping was tested to work correctly with my Apple keyboard over Bluetooth.