### PR TITLE
Allow keycodes in layers in addition to modifiers

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -381,6 +381,8 @@ static int set_layer_entry(const struct config *config,
 static int new_layer(char *s, const struct config *config, struct layer *layer)
 {
 	uint8_t mods;
+	uint8_t keycodes[MAX_LAYER_KEYCODES];
+	size_t nr_keycodes;
 	char *name;
 	char *type;
 
@@ -421,9 +423,11 @@ static int new_layer(char *s, const struct config *config, struct layer *layer)
 
 	} else if (type && !strcmp(type, "layout")) {
 			layer->type = LT_LAYOUT;
-	} else if (type && !parse_modset(type, &mods)) {
+	} else if (type && !parse_modset_and_keycodes(type, &mods, keycodes, &nr_keycodes, 0, ARRAY_SIZE(keycodes))) {
 			layer->type = LT_NORMAL;
 			layer->mods = mods;
+			layer->nr_keycodes = nr_keycodes;
+			memcpy(layer->keycodes, keycodes, nr_keycodes * sizeof(uint8_t));
 	} else {
 		if (type)
 			config_warn("\"%s\" is not a valid layer type, ignoring", type);

--- a/src/config.h
+++ b/src/config.h
@@ -11,6 +11,7 @@
 
 #define MAX_LAYER_NAME_LEN	64
 #define MAX_DESCRIPTOR_ARGS	3
+#define MAX_LAYER_KEYCODES	8
 
 #define MAX_LAYERS		32
 #define MAX_EXP_LEN		512
@@ -100,6 +101,8 @@ struct layer {
 	} type;
 
 	uint8_t mods;
+	uint8_t keycodes[MAX_LAYER_KEYCODES];
+	size_t nr_keycodes;
 	struct descriptor keymap[256];
 
 	struct chord chords[64];

--- a/src/keyboard.h
+++ b/src/keyboard.h
@@ -132,6 +132,9 @@ struct keyboard {
 
 	uint8_t keystate[256];
 
+	uint8_t control_keystate[256];
+	uint8_t layer_keystate[256];
+
 	struct {
 		int x;
 		int y;

--- a/src/keys.h
+++ b/src/keys.h
@@ -292,6 +292,8 @@ struct modifier {
 
 int parse_modset(const char *s, uint8_t *mods);
 int parse_key_sequence(const char *s, uint8_t *code, uint8_t *mods);
+int parse_modset_and_keycodes(const char *s, uint8_t *modsp, uint8_t *keycodesp, size_t *nr_keycodes, size_t min_keycodes, size_t max_keycodes);
+int parse_mod(char c, uint8_t *modp);
 
 extern const struct modifier modifiers[MAX_MOD];
 extern const struct keycode_table_ent keycode_table[256];

--- a/src/string.c
+++ b/src/string.c
@@ -4,6 +4,8 @@
  * © 2019 Raheman Vaiya (see also: LICENSE).
  */
 #include <assert.h>
+#include <stddef.h>
+#include <string.h>
 
 #include "string.h"
 
@@ -106,3 +108,16 @@ size_t str_escape(char *s)
 	return n;
 }
 
+int str_matches_token(const char *s, const char *token_start, size_t token_len)
+{
+	return !strncmp(s, token_start, token_len) && !s[token_len];
+}
+
+const char *str_token_end(const char *s, char delim)
+{
+	const char *token_end = strchr(s, delim);
+	if (!token_end) {
+		token_end = s + strlen(s);
+	}
+	return token_end;
+}

--- a/src/string.h
+++ b/src/string.h
@@ -14,4 +14,6 @@ int utf8_strlen(const char *s);
 
 int is_timeval(const char *s);
 size_t str_escape(char *s);
+int str_matches_token(const char *s, const char *token_start, size_t token_len);
+const char *str_token_end(const char *s, char delim);
 #endif


### PR DESCRIPTION
Another approach to solving #926.

This change adds the ability to use regular key names in addition to modifiers for layers.

Example: Toggles W or Shift+W when holding down the right control key:

```
[ids]
*

[main]
rightcontrol = layer(ctrl_layer)

[ctrl_layer]
w = toggle(key_w)

[ctrl_layer+shift]
w = toggle(key_shift_w)

[key_w:w]

[key_shift_w:S-w]
```

It is even possible to use multiple key names, e.g. `S-w-a`.
