### PR TITLE
keyd-application-mapper: comply with XDG Base Directory Specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ explicitly blacklist these.
 
 	`usermod -aG keyd <user>`
 
-- Populate `~/.config/keyd/app.conf`:
+- Populate `$XDG_CONFIG_HOME/keyd/app.conf` (default: `~/.config/keyd/app.conf`):
 
 E.G
 

--- a/docs/keyd-application-mapper.scdoc
+++ b/docs/keyd-application-mapper.scdoc
@@ -16,11 +16,11 @@ keyd-application-mapper - remap keys when window focus changes
 	purpose of setting mappings for that window in the config file.
 
 *-d, --daemonize*
-	Daemonize, write output to _~/.config/keyd/app.log_ instead of stdout.
+	Daemonize, write output to _$XDG_STATE_HOME/keyd/app.log_ instead of stdout.
 
 # DESCRIPTION
 
-A script which reads _~/.config/keyd/app.conf_ and applies the supplied
+A script which reads _$XDG_CONFIG_HOME/keyd/app.conf_ and applies the supplied
 bindings whenever a window with a matching class comes into focus.
 
 You can think of each section as a set of application specific masks applied

--- a/scripts/keyd-application-mapper
+++ b/scripts/keyd-application-mapper
@@ -23,9 +23,13 @@ from fnmatch import fnmatch
 # Consider reimplmenting in perl or C.
 # Produce more useful error messages :P.
 
-CONFIG_PATH = os.getenv('HOME')+'/.config/keyd/app.conf'
-LOCKFILE = os.getenv('HOME')+'/.config/keyd/app.lock'
-LOGFILE = os.getenv('HOME')+'/.config/keyd/app.log'
+XDG_CONFIG_HOME = os.getenv('XDG_CONFIG_HOME', os.path.join(os.getenv('HOME'), '.config'))
+XDG_STATE_HOME = os.getenv('XDG_STATE_HOME', os.path.join(os.getenv('HOME'), '.local', 'state'))
+XDG_RUNTIME_DIR = os.getenv('XDG_RUNTIME_DIR', XDG_STATE_HOME)
+
+CONFIG_PATH = os.path.join(XDG_CONFIG_HOME, 'keyd', 'app.conf')
+LOCKFILE = os.path.join(XDG_RUNTIME_DIR, 'keyd', 'app.lock')
+LOGFILE = os.path.join(XDG_STATE_HOME, 'keyd', 'app.log')
 
 KEYD_BIN = os.environ.get('KEYD_BIN', 'keyd')
 
@@ -513,6 +517,7 @@ def get_monitor(on_window_change):
 
 def lock():
     global lockfh
+    os.makedirs(os.path.dirname(LOCKFILE), exist_ok=True)
     lockfh = open(LOCKFILE, 'w')
     try:
         fcntl.flock(lockfh, fcntl.LOCK_EX | fcntl.LOCK_NB)
@@ -522,6 +527,7 @@ def lock():
 def daemonize():
     print(f'Daemonizing, log output will be stored in {LOGFILE}...')
 
+    os.makedirs(os.path.dirname(LOGFILE), exist_ok=True)
     fh = open(LOGFILE, 'w')
 
     os.close(1)
@@ -538,7 +544,7 @@ opt.add_argument('-d', '--daemonize', default=False, action='store_true', help='
 args = opt.parse_args()
 
 if not os.path.exists(CONFIG_PATH):
-    die('could not find app.conf, make sure it is in ~/.config/keyd/app.conf')
+    die(f'could not find app.conf, make sure it is in {CONFIG_PATH}')
 
 config = parse_config(CONFIG_PATH)
 lock()


### PR DESCRIPTION
Use paths as described in [XDG Base Directory specification](https://specifications.freedesktop.org/basedir/latest/) for `keyd-application-mapper`