### PR TITLE
add support for iso-level3-shift modifier

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -636,11 +636,12 @@ static int parse_descriptor(char *s,
 		const char *layer = NULL;
 
 		switch (code) {
-			case KEYD_LEFTSHIFT:   layer = "shift"; break;
-			case KEYD_LEFTCTRL:    layer = "control"; break;
-			case KEYD_LEFTMETA:    layer = "meta"; break;
-			case KEYD_LEFTALT:     layer = "alt"; break;
-			case KEYD_RIGHTALT:    layer = "altgr"; break;
+			case KEYD_LEFTSHIFT:        layer = "shift";            break;
+			case KEYD_LEFTCTRL:         layer = "control";          break;
+			case KEYD_LEFTMETA:         layer = "meta";             break;
+			case KEYD_LEFTALT:          layer = "alt";              break;
+			case KEYD_RIGHTALT:         layer = "altgr";            break;
+			case KEYD_ISO_LEVEL3_SHIFT: layer = "iso-level3-shift"; break;
 		}
 
 		if (layer) {
@@ -1015,12 +1016,14 @@ static void config_init(struct config *config)
 	"altgr = layer(altgr)\n"
 	"meta = layer(meta)\n"
 	"control = layer(control)\n"
+	"iso-level3-shift = layer(iso-level3-shift)\n"
 
 	"[control:C]\n"
 	"[shift:S]\n"
 	"[meta:M]\n"
 	"[alt:A]\n"
-	"[altgr:G]\n";
+	"[altgr:G]\n"
+	"[iso-level3-shift:I]\n";
 
 	nw = do_parse(config, default_config, NULL);
 	assert(nw == 0);

--- a/src/keys.c
+++ b/src/keys.c
@@ -8,11 +8,12 @@
 #include "keys.h"
 
 const struct modifier modifiers[MAX_MOD] = {
-	{MOD_ALT, KEYD_LEFTALT},
-	{MOD_ALT_GR, KEYD_RIGHTALT},
-	{MOD_SHIFT, KEYD_LEFTSHIFT},
-	{MOD_SUPER, KEYD_LEFTMETA},
-	{MOD_CTRL, KEYD_LEFTCTRL},
+	{MOD_ALT,        KEYD_LEFTALT},
+	{MOD_ISO_LEVEL3, KEYD_ISO_LEVEL3_SHIFT},
+	{MOD_ALT_GR,     KEYD_RIGHTALT},
+	{MOD_SHIFT,      KEYD_LEFTSHIFT},
+	{MOD_SUPER,      KEYD_LEFTMETA},
+	{MOD_CTRL,       KEYD_LEFTCTRL},
 };
 
 const struct keycode_table_ent keycode_table[256] = {
@@ -45,7 +46,7 @@ const struct keycode_table_ent keycode_table[256] = {
 	[KEYD_RIGHTBRACE] = { "]", "rightbrace", "}" },
 	[KEYD_ENTER] = { "enter", NULL, NULL },
 	[KEYD_LEFTCTRL] = { "leftcontrol", "", NULL },
-	[KEYD_IS_LEVEL3_SHIFT] = { "iso-level3-shift", NULL, NULL }, //Oddly missing from input-event-codes.h, appears to be used as altgr in an english keymap on X
+	[KEYD_ISO_LEVEL3_SHIFT] = { "iso-level3-shift", NULL, NULL }, //Oddly missing from input-event-codes.h, appears to be used as altgr in an english keymap on X
 	[KEYD_A] = { "a", NULL, "A" },
 	[KEYD_S] = { "s", NULL, "S" },
 	[KEYD_D] = { "d", NULL, "D" },
@@ -326,6 +327,9 @@ int parse_modset(const char *s, uint8_t *mods)
 			break;
 		case 'G':
 			*mods |= MOD_ALT_GR;
+			break;
+		case 'I':
+			*mods |= MOD_ISO_LEVEL3;
 			break;
 		default:
 			return -1;

--- a/src/keys.h
+++ b/src/keys.h
@@ -10,13 +10,14 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#define MOD_ISO_LEVEL3	0x20
 #define MOD_ALT_GR	0x10
 #define MOD_CTRL	0x8
 #define MOD_SHIFT	0x4
 #define MOD_SUPER	0x2
 #define MOD_ALT		0x1
 
-#define MAX_MOD 5
+#define MAX_MOD 6
 
 struct keycode_table_ent {
 	const char *name;
@@ -112,7 +113,7 @@ struct modifier {
 #define KEYD_KP3               81
 #define KEYD_KP0               82
 #define KEYD_KPDOT             83
-#define KEYD_IS_LEVEL3_SHIFT   84
+#define KEYD_ISO_LEVEL3_SHIFT  84
 #define KEYD_ZENKAKUHANKAKU    85
 #define KEYD_102ND             86
 #define KEYD_F11               87


### PR DESCRIPTION
This adds support for the iso-level3-shift modifier, which is used by some ergonomically optimized layouts such as Neo, AdNW and KOY that have full X11 and Wayland support.

You might not agree with the tabular-like linting introduced in two places, so please tell me if you'd like that changed.

Also fix the spelling mistake IS -> ISO.

See #1179 for discussion. I have been running the config given in the issue locally for a few days without any problems.