### PR TITLE
Create mock-macos.conf example

### DIFF
--- a/examples/mock-macos.conf
+++ b/examples/mock-macos.conf
@@ -1,0 +1,44 @@
+# Almost MacOS keybindings, achieve 90% without the hassle / complexity to install kinto
+# - Basic Emacs cursor navigation (eg. ctrl+a to move cursor to the start, ctrl+e to move cursor to the end)
+# - Use cmd instead of ctrl (eg. cmd+c for copy, cmd+a for select all)
+# - Use cmd + tab to switch between applications
+
+[ids]
+*
+
+[main]
+leftmeta = layer(command)
+leftcontrol = layer(emacs)
+
+[command:C]
+# App Switcher (Cmd+Tab -> Alt+Tab)
+# When Tab is pressed, we use swapm to swap the current modifier (Super/Command) 
+# with the 'app_switch_state', and we emit 'Alt+Tab'.
+tab = swapm(app_switch_state, A-tab)
+# [app_switch_state] layer
+# This state is active while you are holding Super AFTER pressing Tab.
+# It inherits from Alt (:A) so that the system sees "Alt" held down, keeping the switcher open.
+[app_switch_state:A]
+# Tab cycles forward (Alt+Tab)
+tab = A-tab
+# Shift+Tab cycles backward (Alt+Shift+Tab)
+S-tab = A-S-tab
+# Right arrow cycles forward
+right = A-tab
+# Left arrow cycles backward
+left = A-S-tab
+# [emacs] layer
+# Inherits from Control (:C).
+# This provides the "Global Emacs" experience.
+# We explicitly remap navigation keys to arrows, and editing keys to their Linux equivalents.
+[emacs:C]
+# Navigation
+n = down
+p = up
+f = right
+b = left
+a = home
+e = end
+h = backspace
+# XXX: We map 'l' instead of 'k' here because S-end delete will break terminal app (it will only delete one char instead of everything after cursor)
+l = macro(S-end delete)


### PR DESCRIPTION
Works for me on Ubuntu 25 (with default desktop environment).

I think this is a way better (aka. simpler) approach than kinto.sh.

Also if someone can help me figure out the ctrl-k situation it will be great too :)