### PR TITLE
scripts: Ignore normal windows in floating window detection

### DIFF
--- a/scripts/keyd-application-mapper
+++ b/scripts/keyd-application-mapper
@@ -382,6 +382,7 @@ class XMonitor():
         _NET_WM_STATE = self.dpy.intern_atom('_NET_WM_STATE', False)
         _NET_WM_STATE_ABOVE = self.dpy.intern_atom('_NET_WM_STATE_ABOVE', False)
         _NET_WM_WINDOW_TYPE_NOTIFICATION = self.dpy.intern_atom('_NET_WM_WINDOW_TYPE_NOTIFICATION', False)
+        _NET_WM_WINDOW_TYPE_NORMAL = self.dpy.intern_atom('_NET_WM_WINDOW_TYPE_NORMAL', False)
         _NET_WM_WINDOW_TYPE = self.dpy.intern_atom('_NET_WM_WINDOW_TYPE', False)
 
         def get_floating_window():
@@ -394,9 +395,16 @@ class XMonitor():
 
                 if v and v.value and v.value[0] == _NET_WM_STATE_ABOVE:
                     types = w.get_full_property(_NET_WM_WINDOW_TYPE, Xlib.Xatom.ATOM)
+                    wm_class = w.get_wm_class()
+
+                    # Ignore normal windows
+                    if types and _NET_WM_WINDOW_TYPE_NORMAL in types.value:
+                        dbg(f'skipping normal window: {wm_class}')
+                        continue
 
                     # Ignore persistent notification windows like dunst
                     if not types or _NET_WM_WINDOW_TYPE_NOTIFICATION not in types.value:
+                        dbg(f'get_floating_window found: {wm_class}')
                         return w
 
             return None


### PR DESCRIPTION
Without this patch, `keyd-application-mapper` incorrectly identifies normal windows as floating windows when they have the `_NET_WM_STATE_ABOVE` property set.

This totally breaks the script by causing it to assume that such windows permanently have the focus, preventing it from correctly detecting which other windows have the focus, and therefore not applying any mappings.

This patch solves the problem by checking the window type and skipping windows that have the `_NET_WM_WINDOW_TYPE_NORMAL` type, even when they have the `_NET_WM_STATE_ABOVE` state set.

May fix #521.