### PR TITLE
Graphite: fix issues that made layout unusable

### DIFF
--- a/layouts/graphite
+++ b/layouts/graphite
@@ -1,4 +1,6 @@
 [graphite:layout]
+- = [
+= = ]
 q = b
 w = l
 e = d
@@ -32,6 +34,8 @@ m = p
 shift = layer(graphite_shift)
 
 [graphite_shift:S]
+- = {
+= = }
 q = B
 w = L
 e = D
@@ -42,8 +46,8 @@ u = F
 i = O
 o = U
 p = J
-- = :
-= = +
+[ = :
+] = +
 a = N
 s = R
 d = T
@@ -52,8 +56,8 @@ h = Y
 j = H
 k = A
 l = E
-i = I
-, = ?
+; = I
+' = ?
 z = Q
 x = X
 c = M
@@ -61,6 +65,6 @@ v = C
 b = V
 n = K
 m = P
-, = <
+, = >
 . = "
 / = <


### PR DESCRIPTION
multiple issues:
- `i = I` which was bound twice (`;` is `i`), made `I` impossible to type, and also rebinding `i` which made it impossible to type `O`
- the brackets are in the wrong place, multiple keys to type `=`, and `[ ]` were unbound with no replacements
- duplicate to `<` (rather than `>`)
- `?` is in wrong place, `'` was never rebound

https://github.com/rdavison/graphite-layout

![layout img](https://user-images.githubusercontent.com/630055/230756923-cbe4adab-22e5-468e-b0ca-068d4a2a7e67.png)