### PR TITLE
Replacing removed global.stage.get_title() (removed in GNOME 45+) with focus-window title as a safe fallback.

### DIFF
--- a/data/gnome-extension-45/extension.js
+++ b/data/gnome-extension-45/extension.js
@@ -50,7 +50,9 @@ export default class KeydExtension extends Extension {
 
 		Main.layoutManager.connectObject(
 			'system-modal-opened', () => {
-				send(`system-modal	${global.stage.get_title()}\n`);
+				const win = global.display.focus_window;
+				const title = win ? win.get_title() : '';
+				send(`system-modal	${title}\n`);
 			},
 			this
 		);

--- a/data/gnome-extension-45/metadata.json
+++ b/data/gnome-extension-45/metadata.json
@@ -2,6 +2,6 @@
 	"name": "keyd",
 	"description": "Used by keyd to obtain active window information.",
 	"uuid": "keyd@keyd.rvaiya.github.com",
-	"shell-version": [ "45", "46", "47", "48", "49"]
+	"shell-version": [ "45", "46", "47", "48", "49", "50"]
 }
 

--- a/data/gnome-extension/extension.js
+++ b/data/gnome-extension/extension.js
@@ -50,7 +50,9 @@ function init() {
 
 			Main.layoutManager.connectObject(
 				'system-modal-opened', () => {
-					send(`system-modal	${global.stage.get_title()}\n`);
+					const win = global.display.focus_window;
+					const title = win ? win.get_title() : '';
+					send(`system-modal	${title}\n`);
 				},
 				this
 			);


### PR DESCRIPTION
The keyd extension is trying to call global.stage.get_title(), 
which no longer exists in GNOME's Clutter library interface.

You can see an error like this in the log.
gnome-shell[229921]: JS ERROR: TypeError: global.stage.get_title is not a function
                                            enable/<@file:///home/mward/.local/share/gnome-shell/extensions/keyd/extension.js:53:39
                                            open@resource:///org/gnome/shell/ui/screenshot.js:1664:28
                                            async*_init/</<@resource:///org/gnome/shell/ui/status/system.js:125:35
                                            
I could reproduce it in Ubuntu 26.04 using             

Screenshot — Quick Settings → Screenshot (or Print Screen).
Power / logout modal — Power menu → Log Out (or whatever opens the confirm dialog) → Cancel (don’t actually log out).

Both log global.stage.get_title is not a function at extension.js:53 with the old extension.
                              