### PR TITLE
Instructions for Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ between releases. Releases are [tagged](https://github.com/rvaiya/keyd/tags), an
     make && sudo make install
     sudo systemctl enable --now keyd
 
+## Homebrew (macOS/Linux)
+
+    brew install keyd
+
 # Quickstart
 
 1. Install and start keyd (e.g `sudo systemctl enable keyd --now`)


### PR DESCRIPTION
keyd is now [available](https://github.com/Homebrew/homebrew-core/commit/a2e48bce3cf593df0d349ab858c1a96b80fa3433) to install via [Homebrew](https://brew.sh).