### PR TITLE
Allow one app.conf block to match against multiple apps

### DIFF
--- a/docs/keyd-application-mapper.scdoc
+++ b/docs/keyd-application-mapper.scdoc
@@ -50,6 +50,10 @@ to be matched, and may optionally contain unix style wildcards (\*). For example
 _[gnome|\*find\*]_ will match any window with a class of _gnome_ and a title
 containing the substring _find_.
 
+_<class exp>_ may also contain multiple comma-separated patterns to match against
+multiple applications (e.g _[chromium,firefox*]_). A section matches when any of
+the comma-separated class patterns match.
+
 E.G:
 
 ```
@@ -63,9 +67,9 @@ E.G:
 
 	alt.1  = macro(Inside space st)
 
-	[chromium]
+	[chromium,firefox*,google-chrome|*Homepage*]
 
-	control.1 = macro(Inside space chrome!)
+	control.1 = macro(Browsing homepage!)
 	alt.] = C-tab
 	alt.[ = C-S-tab
 	alt.t = C-t

--- a/scripts/keyd-application-mapper
+++ b/scripts/keyd-application-mapper
@@ -72,14 +72,16 @@ def parse_config(path):
             a = line[1:-1].split('|')
 
             if len(a) < 2:
-                cls = a[0]
+                classes = a[0].split(',')
                 title = '*'
             else:
-                cls = a[0]
+                classes = a[0].split(',')
                 title = a[1]
 
             bindings = []
-            config.append((cls, title, bindings))
+            for cls in classes:
+                cls = cls.strip()
+                config.append((cls, title, bindings))
         elif line == '':
             continue
         elif line.startswith('#'):


### PR DESCRIPTION
Allows multiple applications to be specified for a block of mappings, by separating each with a `,`

Example:

```
[chromium,firefox*,google-chrome|*Homepage*]

control.1 = macro(Inside browser!)
alt.] = C-tab
alt.[ = C-S-tab
alt.t = C-t
```

The "Homepage" match applies to all those on the left.

---

Alternative:

```
# We could consider something like this (similar to VSCode configs)
[chromium|*Homepage*][firefox*|*Homepage*][google-chrome|*Homepage*]

# Or (similar to issue 505 below)
[(chromium|firefox*|google-chrome)|*Homepage*]
```